### PR TITLE
Added Radio Buttons, Collapsing Headers and other tweaks.

### DIFF
--- a/src/client/Iris/config.lua
+++ b/src/client/Iris/config.lua
@@ -43,7 +43,7 @@ local TemplateConfig = {
         ButtonActiveTransparency = 0,
 
         HeaderColor = Color3.fromRGB(66, 150, 250),
-        HeaderTransparency = 0.31,
+        HeaderTransparency = 0.69,
         HeaderHoveredColor = Color3.fromRGB(66, 150, 250),
         HeaderHoveredTransparency = 0.2,
         HeaderActiveColor = Color3.fromRGB(66, 150, 250),

--- a/src/client/Iris/demoWindow.lua
+++ b/src/client/Iris/demoWindow.lua
@@ -9,11 +9,18 @@ return function(Iris)
     local widgetDemos = {
         Basic = function()
             Iris.Tree({"Basic"})
+				local radioButtonState = Iris.State(1)
                 Iris.Button({"Button"})
                 Iris.SmallButton({"SmallButton"})
                 Iris.Text({"Text"})
                 Iris.TextWrapped({string.rep("Text Wrapped ", 5)})
                 Iris.TextColored({"Colored Text", Color3.fromRGB(255, 128, 0)})
+				Iris.SameLine()
+					Iris.RadioButton({"Index '1'", 1}, radioButtonState)
+					Iris.RadioButton({"Index 'two'", "two"}, radioButtonState)
+					Iris.RadioButton({"Index 'false'", false}, radioButtonState)
+				Iris.End()
+				Iris.Text({"The Index is: " .. tostring(radioButtonState.value.value)})
             Iris.End()
         end,
 
@@ -34,6 +41,21 @@ return function(Iris)
                 
             Iris.End()
         end,
+
+		CollapsingHeader = function()
+			Iris.Tree({"Collapsing Headers"})
+				Iris.CollapsingHeader({"A header"})
+					Iris.Text({"This is under the first header!"})
+				Iris.End()
+
+				local secondHeader = Iris.State(true)
+				Iris.CollapsingHeader({"Another header"}, { isUncollapsed = secondHeader })
+					if Iris.Button({"Shhh... secret button!"}).clicked() then
+						secondHeader:set(false)
+					end
+				Iris.End()
+			Iris.End()
+		end,
 
         Group = function()
             Iris.Tree({"Groups"})
@@ -117,7 +139,7 @@ return function(Iris)
             Iris.PopConfig()
         end
     }
-    local widgetDemosOrder = {"Basic", "Tree", "Group", "Indent", "InputNum", "InputText", "Tooltip"}
+    local widgetDemosOrder = {"Basic", "Tree", "CollapsingHeader", "Group", "Indent", "InputNum", "InputText", "Tooltip"}
 
     local function recursiveTree()
         local theTree = Iris.Tree({"Recursive Tree"})
@@ -214,6 +236,14 @@ return function(Iris)
                         {"",             "unchecked: boolean", ""                  }
                     })
                 Iris.End()
+				Iris.NextColumn()
+				Iris.Tree({"\nIris.RadioButton\n", [Iris.Args.Tree.NoIndent] = true, [Iris.Args.Tree.SpanAvailWidth] = true})
+					parse2DArray({
+						{"Arguments",	 "Events", "States"		 			 },	
+						{"Text: string", "activated: boolean",	 "value: any"},
+						{"Value: any",	 "deactivated: boolean", ""			 }
+					})
+				Iris.End()
                 Iris.NextColumn()
                 Iris.Tree({"\nIris.Tree\n", [Iris.Args.Tree.NoIndent] = true, [Iris.Args.Tree.SpanAvailWidth] = true})
                     parse2DArray({
@@ -221,6 +251,14 @@ return function(Iris)
                         {"Text: string",            "collapsed: boolean",   "isUncollapsed: boolean"},
                         {"SpanAvailWidth: boolean", "uncollapsed: boolean", ""                      },
                         {"NoIndent: boolean",       "",                     ""                      }
+                    })
+                Iris.End()
+				Iris.NextColumn()
+                Iris.Tree({"\nIris.CollapsingHeader\n", [Iris.Args.Tree.NoIndent] = true, [Iris.Args.Tree.SpanAvailWidth] = true})
+                    parse2DArray({
+                        {"Arguments",    "Events",               "States"                },
+                        {"Text: string", "collapsed: boolean",   "isUncollapsed: boolean"},
+                        {"",			 "uncollapsed: boolean", ""                      },
                     })
                 Iris.End()
                 Iris.NextColumn()
@@ -641,7 +679,7 @@ return function(Iris)
 
     -- showcases how events can be used
     local function widgetEventInteractivity()
-        Iris.Tree({"Widget Event Interactivity"})
+        Iris.CollapsingHeader({"Widget Event Interactivity"})
             local clickCount = Iris.State(0)
             if Iris.Button({"Click to increase Number"}).clicked() then
                 clickCount:set(clickCount:get() + 1)
@@ -674,7 +712,7 @@ return function(Iris)
 
     -- showcases how state can be used
     local function widgetStateInteractivity()
-        Iris.Tree({"Widget State Interactivity"})
+        Iris.CollapsingHeader({"Widget State Interactivity"})
             local checkbox0 = Iris.Checkbox({"Widget-Generated State"})
             Iris.Text({`isChecked: {checkbox0.state.isChecked.value}\n`})
             
@@ -708,7 +746,7 @@ return function(Iris)
 
     -- showcases how dynamic styles can be used
     local function dynamicStyle()
-        Iris.Tree({"Dynamic Styles"})
+        Iris.CollapsingHeader({"Dynamic Styles"})
             local colorH = Iris.State(0)
             Iris.SameLine()
             if Iris.Button({"Change Color"}).clicked() then
@@ -726,7 +764,7 @@ return function(Iris)
     local function tablesDemo()
         local showTablesTree = Iris.State(false)
 
-        Iris.Tree({"Tables & Columns", [Iris.Args.Tree.NoIndent] = true}, {isUncollapsed = showTablesTree})
+        Iris.CollapsingHeader({"Tables & Columns"}, {isUncollapsed = showTablesTree})
         if showTablesTree.value == false then
             -- optimization to skip code which draws GUI which wont be seen.
             -- its a trade off because when the tree becomes opened widgets will all have to be generated again.
@@ -844,7 +882,7 @@ return function(Iris)
 
             Iris.Separator()
 
-            Iris.Tree({"Window Options"})
+            Iris.CollapsingHeader({"Window Options"})
                 Iris.Table({3, false, false, false})
                     Iris.NextColumn()
                     Iris.Checkbox({"NoTitleBar"}, {isChecked = NoTitleBar})
@@ -869,13 +907,15 @@ return function(Iris)
 
             widgetStateInteractivity()
 
-            recursiveTree()
+			Iris.CollapsingHeader({"Recursive Tree"})
+            	recursiveTree()
+			Iris.End()
 
             dynamicStyle()
 
             Iris.Separator()
 
-            Iris.Tree({"Widgets"})
+            Iris.CollapsingHeader({"Widgets"})
                 for _, name in widgetDemosOrder do
                     widgetDemos[name]()
                 end


### PR DESCRIPTION
# Additions:
## Radio Buttons
- Circular clickable buttons.
- Contains an 'value' passed as an argument which determines the state value when that radio button is clicked.
- Added to the basic widgets demo.

## Collapsing Headers
- Very similar to tree nodes but can be clicked across the entire window width and are much larger.
- They do not indent any children so make the best use as top-level window nodes.
- This code be combined into the tree node and passed as arguments instead.

# Tweaks:
- Added padding to tree nodes more inilne with ImGui. This can be reverted and is just stylistic choice.
- Changed an incorrect transparency style value (alpha rather than transparency).
- Updated all the top-level tree nodes in the demo window to be collapsing headers. This is also optional but makes a good example of where they can be used.
- Fixed some type issues of 'table' into '{ [any]: any }' which allows for types.
- applyPadding with a 'forceNoPadding' argument did actually apply a padding leading to double padding for certain situations. There is another paramater to definitely force no padding.

## Notes:
- I have been working on my own version of ImGui for Roblox but this seems like a better designed library which I would like to help with.
- Many of the changes are just stylistic or preferences, specifically removing variable shadowing and changed i, v to actually have understandable names and can just be left.
- Would it be wise to refactor the widgets into individual files rather than in a single 2000+ line file? It makes coding slightly more difficult and luau-lsp seems to struggle with such a large file.