### PR TITLE
Updates to ContentWidth and Bug Fixes

### DIFF
--- a/src/client/Iris/config.lua
+++ b/src/client/Iris/config.lua
@@ -43,9 +43,9 @@ local TemplateConfig = {
         ButtonActiveTransparency = 0,
 
         SliderGrabColor = Color3.fromRGB(66, 150, 250),
-        SliderGrabTransparency = 0.22,
+        SliderGrabTransparency = 0, --0.22,
         SliderGrabActiveColor = Color3.fromRGB(117, 138, 204),
-        SliderGrabActiveTransparency = 0.4,
+        SliderGrabActiveTransparency = 0, --0.4,
 
         HeaderColor = Color3.fromRGB(66, 150, 250),
         HeaderTransparency = 0.69,
@@ -161,7 +161,7 @@ local TemplateConfig = {
 
     sizeDefault = { -- Dear, ImGui default
         ItemWidth = UDim.new(1, 0),
-        ContentWidth = UDim.new(0, 125),
+        ContentWidth = UDim.new(0.65, 0),
 
         WindowPadding = Vector2.new(8, 8),
         WindowResizePadding = Vector2.new(6, 6),
@@ -186,7 +186,7 @@ local TemplateConfig = {
     },
     sizeClear = { -- easier to read and manuveure
         ItemWidth = UDim.new(1, 0),
-        ContentWidth = UDim.new(0, 125),
+        ContentWidth = UDim.new(0.65, 0),
 
         WindowPadding = Vector2.new(12, 8),
         WindowResizePadding = Vector2.new(8, 8),

--- a/src/client/Iris/demoWindow.lua
+++ b/src/client/Iris/demoWindow.lua
@@ -73,7 +73,7 @@ return function(Iris)
 				local secondHeader = Iris.State(true)
 				Iris.CollapsingHeader({"Another header"}, { isUncollapsed = secondHeader })
 					if Iris.Button({"Shhh... secret button!"}).clicked() then
-						secondHeader:set(false)
+						secondHeader:set(true)
 					end
 				Iris.End()
 			Iris.End()
@@ -116,6 +116,7 @@ return function(Iris)
                 local NoField, NoButtons, Min, Max, Increment, Format = 
                 Iris.State(false), Iris.State(false), Iris.State(0), Iris.State(100), Iris.State(1), Iris.State("%d")
 
+                Iris.PushConfig({ContentWidth = UDim.new(1, -120)})
                 local InputNum = Iris.InputNum({"Input Number",
                     [Iris.Args.InputNum.NoField] = NoField.value,
                     [Iris.Args.InputNum.NoButtons] = NoButtons.value,
@@ -124,6 +125,7 @@ return function(Iris)
                     [Iris.Args.InputNum.Increment] = Increment.value,
                     [Iris.Args.InputNum.Format] = Format.value,
                 })
+                Iris.PopConfig()
                 Iris.Text({"The Value is: " .. InputNum.number.value})
                 if Iris.Button({"Randomize Number"}).clicked() then
                     InputNum.number:set(math.random(1,99))
@@ -143,7 +145,7 @@ return function(Iris)
                     Iris.Text({"Slider Numbers"})
                     helpMarker("ctrl + click slider number widgets to input a number")
                 Iris.End()
-                Iris.PushConfig({ContentWidth = UDim.new(0, 350)})
+                Iris.PushConfig({ContentWidth = UDim.new(1, -120)})
                     Iris.SliderNum({"Slide Int", 1, 1, 8})
                     Iris.SliderNum({"Slide Float", 0.01, 0, 100})
                     Iris.SliderNum({"Small Numbers", 0.001, -2, 1, "%f radians"})
@@ -158,7 +160,7 @@ return function(Iris)
                     Iris.Text({"Drag Numbers"})
                     helpMarker("ctrl + click or double click drag number widgets to input a number, hold shift/alt while dragging to increase/decrease speed")
                 Iris.End()
-                Iris.PushConfig({ContentWidth = UDim.new(0, 350)})
+                Iris.PushConfig({ContentWidth = UDim.new(1, -120)})
                     Iris.DragNum({"Drag Int"})
                     Iris.DragNum({"Slide Float", 0.001, -10, 10})
                     Iris.DragNum({"Percentage", 1, 0, 100, "%d %%"})
@@ -466,7 +468,7 @@ return function(Iris)
                 helpMarker("every widget and state has an ID which Iris tracks to remember which widget is which. below lists all widgets and states, with their respective IDs")
             Iris.End()
 
-            Iris.PushConfig({ItemWidth = UDim.new(0.5, 100)})
+            Iris.PushConfig({ItemWidth = UDim.new(1, -150)})
             local enteredText = Iris.InputText({"ID field"}, {text = Iris.State(runtimeInfoWindow.ID)}).text.value
             Iris.PopConfig()
 
@@ -997,6 +999,48 @@ return function(Iris)
         end
     end
 
+	local function layoutDemo()
+		Iris.CollapsingHeader({"Widget Layout"})
+			Iris.Tree({"Content Width"})
+				local value = Iris.State(50)
+
+				Iris.Text({"The Content Width is a size property which determines the width of input fields."})
+				Iris.SameLine()
+					Iris.Text({"By default the value is UDim.new(0.65, 0)"})
+					helpMarker("This is the default value from Dear ImGui.\nIt is 65% of the window width.")
+				Iris.End()
+				Iris.Text({"This works well, but sometimes we know how wide elements are going to be and want to maximise the space."})
+				Iris.Text({"Therefore, we can use Iris.PushConfig() to change the width"})
+
+				Iris.Separator()
+
+				Iris.SameLine()
+					Iris.Text({"Content Width = 150 pixels"})
+					helpMarker("UDim.new(0, 150)")
+				Iris.End()
+				Iris.PushConfig({ContentWidth = UDim.new(0, 150)})
+					Iris.DragNum({"number", 1, 0, 100}, {number = value})
+				Iris.PopConfig()
+
+				Iris.SameLine()
+					Iris.Text({"Content Width = 50% window width"})
+					helpMarker("UDim.new(0.5, 0)")
+				Iris.End()
+				Iris.PushConfig({ContentWidth = UDim.new(0.5, 0)})
+					Iris.DragNum({"number", 1, 0, 100}, {number = value})
+				Iris.PopConfig()
+
+				Iris.SameLine()
+					Iris.Text({"Content Width = -150 pixels from the right side"})
+					helpMarker("UDim.new(1, -150)")
+				Iris.End()
+				Iris.PushConfig({ContentWidth = UDim.new(1, -150)})
+					Iris.DragNum({"number", 1, 0, 100}, {number = value})
+				Iris.PopConfig()
+			Iris.End()
+		Iris.End()
+	end	
+
     -- showcases how widgets placed outside of a window are placed inside root
     local function windowlessDemo()
         Iris.PushConfig({ItemWidth = UDim.new(0, 150)})
@@ -1096,6 +1140,8 @@ return function(Iris)
             Iris.End()
 
             tablesDemo()
+
+			layoutDemo()
         Iris.End()
 
         if showRecursiveWindow.value then

--- a/src/client/Iris/widgets/Combo.lua
+++ b/src/client/Iris/widgets/Combo.lua
@@ -230,7 +230,7 @@ return function(Iris, widgets)
 
             ComboLine.Parent = Combo
 
-            local PreviewContainer = Instance.new("Frame")
+            local PreviewContainer = Instance.new("TextButton")
             PreviewContainer.Name = "PreviewContainer"
             PreviewContainer.Size = UDim2.fromScale(0, 1)
             PreviewContainer.AutomaticSize = Enum.AutomaticSize.X
@@ -238,6 +238,7 @@ return function(Iris, widgets)
             PreviewContainer.BackgroundTransparency = 1
             PreviewContainer.ZIndex = thisWidget.ZIndex + 2
             PreviewContainer.LayoutOrder = thisWidget.ZIndex + 2
+			PreviewContainer.Text = ""
             widgets.UIListLayout(PreviewContainer, Enum.FillDirection.Horizontal, UDim.new(0, 0))
 
             PreviewContainer.Parent = ComboLine
@@ -344,6 +345,7 @@ return function(Iris, widgets)
             -- appear over everything else
             ChildContainer.ZIndex = thisWidget.ZIndex + 6
             ChildContainer.LayoutOrder = thisWidget.ZIndex + 6
+			ChildContainer.ClipsDescendants = true
 
             local ChildContainerUIListLayout = widgets.UIListLayout(ChildContainer, Enum.FillDirection.Vertical, UDim.new(0, Iris._config.ItemSpacing.Y))
             ChildContainerUIListLayout.VerticalAlignment = Enum.VerticalAlignment.Top

--- a/src/client/Iris/widgets/Input.lua
+++ b/src/client/Iris/widgets/Input.lua
@@ -1,4 +1,3 @@
-local TextService = game:GetService("TextService")
 local UserInputService = game:GetService("UserInputService")
 return function(Iris, widgets)
 
@@ -14,7 +13,7 @@ return function(Iris, widgets)
     local function GenerateRootFrame(thisWidget, name)
         local Frame = Instance.new("Frame")
         Frame.Name = name
-        Frame.Size = UDim2.new(Iris._config.ContentWidth, UDim.new(0, 0))
+        Frame.Size = UDim2.fromScale(1, 0)
         Frame.BackgroundTransparency = 1
         Frame.BorderSizePixel = 0
         Frame.ZIndex = thisWidget.ZIndex
@@ -131,16 +130,18 @@ return function(Iris, widgets)
             InputFieldContainer.Name = "InputFieldContainer"
             widgets.applyFrameStyle(InputFieldContainer)
             widgets.applyTextStyle(InputFieldContainer)
+			widgets.UISizeConstraint(InputFieldContainer, Vector2.new(1, 0))
             InputFieldContainer.TextXAlignment = Enum.TextXAlignment.Center
             InputFieldContainer.ZIndex = thisWidget.ZIndex + 1
             InputFieldContainer.LayoutOrder = thisWidget.ZIndex + 1
-            InputFieldContainer.Size = UDim2.new(1, 0, 0, 0)
+            InputFieldContainer.Size = UDim2.new(Iris._config.ContentWidth, UDim.new(0, 0))
             InputFieldContainer.AutomaticSize = Enum.AutomaticSize.Y
             InputFieldContainer.AutoButtonColor = false
             InputFieldContainer.Text = ""
             InputFieldContainer.BackgroundColor3 = Iris._config.FrameBgColor
             InputFieldContainer.BackgroundTransparency = Iris._config.FrameBgTransparency
             InputFieldContainer.Parent = DragNum
+			InputFieldContainer.ClipsDescendants = true
 
             widgets.applyInteractionHighlights(InputFieldContainer, InputFieldContainer, {
                 ButtonColor = Iris._config.FrameBgColor,
@@ -290,16 +291,29 @@ return function(Iris, widgets)
             InputFieldContainer.Name = "InputFieldContainer"
             widgets.applyFrameStyle(InputFieldContainer)
             widgets.applyTextStyle(InputFieldContainer)
+			widgets.UISizeConstraint(InputFieldContainer, Vector2.new(1, 0))
             InputFieldContainer.TextXAlignment = Enum.TextXAlignment.Center
             InputFieldContainer.ZIndex = thisWidget.ZIndex + 1
             InputFieldContainer.LayoutOrder = thisWidget.ZIndex + 1
-            InputFieldContainer.Size = UDim2.new(1, 0, 0, 0)
+            InputFieldContainer.Size = UDim2.new(Iris._config.ContentWidth, UDim.new(0, 0))
             InputFieldContainer.AutomaticSize = Enum.AutomaticSize.Y
             InputFieldContainer.AutoButtonColor = false
             InputFieldContainer.Text = ""
             InputFieldContainer.BackgroundColor3 = Iris._config.FrameBgColor
             InputFieldContainer.BackgroundTransparency = Iris._config.FrameBgTransparency
             InputFieldContainer.Parent = SliderNum
+			InputFieldContainer.ClipsDescendants = true
+
+			local OverlayText = Instance.new("TextLabel")
+			OverlayText.Name = "OverlayText"
+			OverlayText.Size = UDim2.fromScale(1, 1)
+			OverlayText.BackgroundTransparency = 1
+			OverlayText.BorderSizePixel = 0
+			OverlayText.ZIndex = thisWidget.ZIndex + 10
+			widgets.applyTextStyle(OverlayText)
+			OverlayText.TextXAlignment = Enum.TextXAlignment.Center
+			OverlayText.Parent = InputFieldContainer
+			OverlayText.ClipsDescendants = true
 
             widgets.applyInteractionHighlights(InputFieldContainer, InputFieldContainer, {
                 ButtonColor = Iris._config.FrameBgColor,
@@ -391,7 +405,7 @@ return function(Iris, widgets)
             local GrabBar = InputFieldContainer.GrabBar
             local InputField = InputFieldContainer.InputField
             local newText = string.format(thisWidget.arguments.Format or ((thisWidget.arguments.Increment or 1) >= 1 and "%d" or "%f"), thisWidget.state.number.value)
-            InputFieldContainer.Text = newText
+            InputFieldContainer.OverlayText.Text = newText
             InputField.Text = tostring(thisWidget.state.number.value)
 
             local Increment = thisWidget.arguments.Increment or 1
@@ -446,15 +460,18 @@ return function(Iris, widgets)
             InputField.Name = "InputField"
             widgets.applyFrameStyle(InputField)
             widgets.applyTextStyle(InputField)
+			widgets.UISizeConstraint(InputField, Vector2.new(1, 0))
             InputField.UIPadding.PaddingLeft = UDim.new(0, Iris._config.ItemInnerSpacing.X)
             InputField.ZIndex = thisWidget.ZIndex + 1
             InputField.LayoutOrder = thisWidget.ZIndex + 1
+			InputField.Size = UDim2.new(Iris._config.ContentWidth, UDim.new(0, 0))
             InputField.AutomaticSize = Enum.AutomaticSize.Y
             InputField.BackgroundColor3 = Iris._config.FrameBgColor
             InputField.BackgroundTransparency = Iris._config.FrameBgTransparency
             InputField.ClearTextOnFocus = false
             InputField.TextTruncate = Enum.TextTruncate.AtEnd
             InputField.Parent = InputNum
+			InputField.ClipsDescendants = true
     
             InputField.FocusLost:Connect(function()
                 local newValue = tonumber(InputField.Text)
@@ -523,9 +540,9 @@ return function(Iris, widgets)
     
             local inputButtonsTotalWidth = Iris._config.TextSize * 2 + Iris._config.ItemInnerSpacing.X * 2 + Iris._config.WindowPadding.X + 4
             if thisWidget.arguments.NoButtons then
-                InputField.Size = UDim2.new(1, 0, 0, 0)
+                InputField.Size = UDim2.new(Iris._config.ContentWidth, UDim.new(0, 0))
             else
-                InputField.Size = UDim2.new(1, -inputButtonsTotalWidth, 0, 0)
+                InputField.Size = UDim2.new(Iris._config.ContentWidth + UDim.new(0, -inputButtonsTotalWidth), UDim.new(0, 0))
             end
         end,
         Discard = function(thisWidget)
@@ -574,6 +591,7 @@ return function(Iris, widgets)
             InputField.Name = "InputField"
             widgets.applyFrameStyle(InputField)
             widgets.applyTextStyle(InputField)
+			widgets.UISizeConstraint(InputField, Vector2.new(1, 0)) -- prevents sizes beaking when getting too small.
             InputField.UIPadding.PaddingLeft = UDim.new(0, Iris._config.ItemInnerSpacing.X)
             InputField.UIPadding.PaddingRight = UDim.new(0, 0)
             InputField.ZIndex = thisWidget.ZIndex + 1
@@ -586,6 +604,7 @@ return function(Iris, widgets)
             InputField.Text = ""
             InputField.PlaceholderColor3 = Iris._config.TextDisabledColor
             InputField.TextTruncate = Enum.TextTruncate.AtEnd
+			InputField.ClipsDescendants = true
     
             InputField.FocusLost:Connect(function()
                 thisWidget.state.text:set(InputField.Text)

--- a/src/client/Iris/widgets/Tree.lua
+++ b/src/client/Iris/widgets/Tree.lua
@@ -86,6 +86,7 @@ return function(Iris, widgets)
             ChildContainer.Size = UDim2.fromScale(1, 0)
             ChildContainer.AutomaticSize = Enum.AutomaticSize.Y
             ChildContainer.Visible = false
+			ChildContainer.ClipsDescendants = true
             ChildContainer.Parent = Tree
     
             widgets.UIListLayout(ChildContainer, Enum.FillDirection.Vertical, UDim.new(0, Iris._config.ItemSpacing.Y))
@@ -211,6 +212,7 @@ return function(Iris, widgets)
             ChildContainer.Size = UDim2.fromScale(1, 0)
             ChildContainer.AutomaticSize = Enum.AutomaticSize.Y
             ChildContainer.Visible = false
+			ChildContainer.ClipsDescendants = true
             ChildContainer.Parent = CollapsingHeader
     
             widgets.UIListLayout(ChildContainer, Enum.FillDirection.Vertical, UDim.new(0, Iris._config.ItemSpacing.Y))

--- a/src/client/Iris/widgets/Window.lua
+++ b/src/client/Iris/widgets/Window.lua
@@ -443,6 +443,7 @@ return function(Iris, widgets)
             ChildContainer.AutomaticSize = Enum.AutomaticSize.None
             ChildContainer.Size = UDim2.fromScale(1, 1)
             ChildContainer.Selectable = false
+			ChildContainer.ClipsDescendants = true
 
             ChildContainer.AutomaticCanvasSize = Enum.AutomaticSize.Y
             ChildContainer.ScrollBarImageTransparency = Iris._config.ScrollbarGrabTransparency

--- a/src/client/Iris/widgets/init.lua
+++ b/src/client/Iris/widgets/init.lua
@@ -85,8 +85,8 @@ return function(Iris)
 
     function widgets.UISizeConstraint(Parent, MinSize, MaxSize)
         local UISizeConstraintInstance = Instance.new("UISizeConstraint")
-        UISizeConstraintInstance.MinSize = MinSize
-        UISizeConstraintInstance.MaxSize = MaxSize
+        UISizeConstraintInstance.MinSize = MinSize or UISizeConstraintInstance.MinSize -- made these optional
+        UISizeConstraintInstance.MaxSize = MaxSize or UISizeConstraintInstance.MaxSize
         UISizeConstraintInstance.Parent = Parent
         return UISizeConstraintInstance
     end


### PR DESCRIPTION
# Additions:
## Content Width
- The content width was relatively simple to make work. The container is full width and the input takes up a proportion of that width. Most elements will work with 0.65 scale but the demo window has custom widths as seen in the demo window.

## Layout Demo Section
- A new Layout demo section has been added which showcases the content width changes and how to use them.

# Tweaks:
- Changed the slider transparency. I'm not sure why they were partially transparent. Inline with Dear ImGui, there should be fully opaque.
- Changed the content width default value to 65% inline with Dear ImGui.
- Input fields have a minimum width of 1 to prevent weird sizing issues.
- The text for a drag input was under the drag bar. A new textlabel is placed on top to ensure the text is always on top.

# Bug Fixes:
- The Combo box did not sink inputs meaning you could move the window around whilst the combo box was open, done by holding down on the box and just moving the mouse. By changing it to a button, the input is now sunk.
- Some containers did not properly clip descendants.

## Notes:
- The changes to content width have broken the style editor. Seeing as UDim and Color input fields seem to be a new focus area, I haven't attempted to fix them. The issue is because the new width of each input is the full screen width which pushes everything else away. This does prevent having elements in the sameline for input fields so this may need to change.
- As always, some changes are stylistic and up to preference so change anything which needs it.