### PR TITLE
Added Types and Tweaks

### DIFF
--- a/src/client/Iris/Types.lua
+++ b/src/client/Iris/Types.lua
@@ -153,7 +153,7 @@ export type Iris = {
 	_widgetState: (thisWidget: Widget, stateName: string, initialValue: any) -> State,
 
 	Init: (parentInstance: BasePlayerGui?, eventConnection: (RBXScriptConnection | () -> {})?) -> (),
-	Connect: (callback: () -> ()) -> (),
+	Connect: (self: Iris, callback: () -> ()) -> (),
 
 	_DiscardWidget: (widgetToDiscard: Widget) -> (),
 	_GenNewWidget: (widgetType: string, arguments: Arguments, widgetState: States?, ID: ID) -> Widget,

--- a/src/client/Iris/Types.lua
+++ b/src/client/Iris/Types.lua
@@ -1,0 +1,151 @@
+export type ID = string
+
+export type State = {
+	value: any,
+	ConnectedWidgets: { [ID]:  Widget },
+	ConnectedFunctions: { (any) -> () },
+
+	get: (self: State) -> any,
+	set: (self: State, newValue: any) -> (),
+	onChange: (self: State, funcToConnect: (any) -> ()) -> (),
+}
+export type States = { [string]: State }
+
+export type Event = {
+	Init: (Widget) -> (),
+	Get: (Widget) -> (boolean)
+}
+export type Events = { [string]: Event }
+
+export type Widget = {
+	ID: ID,
+	type: string,
+	state: State,
+
+	parentWidget: Widget,
+	Instance: GuiObject,
+	arguments: Arguments,
+
+	ZIndex: number,
+
+	trackedEvents: {},
+	lastCycleTick: number
+}
+
+export type Argument = any
+export type Arguments = { [string]: Argument }
+export type WidgetArguments = { [number]: Argument }
+
+export type WidgetClass = {
+	Generate: (thisWidget: Widget) -> (GuiObject),
+	Discard: (thisWidget: Widget) -> (),
+	Update: (thisWidget: Widget) -> (),
+
+	Args: { [string]: number },
+	Events: Events,
+	hasChildren: boolean,
+	hasState: boolean,
+	ArgNames: { [number]: string },
+
+	GenerateState: (thisWidget: Widget) -> (),
+	UpdateState: (thisWidget: Widget) -> (),
+
+	ChildAdded: (thisWidget: Widget) -> (GuiObject),
+	ChildDiscarded: (thisWidget: Widget, thisChild: Widget) -> (),
+}
+
+export type Iris = {
+	_started: boolean,
+	_globalRefreshRequested: boolean,
+	_localRefreshActive: boolean,
+	_widgets: { [string]: WidgetClass },
+	_rootConfig: {},
+	_config: {},
+	_rootInstance: GuiObject,
+	_rootWidget: Widget,
+	_states: { [ID]: State },
+	_postCycleCallbacks: {},
+	_connectedFunctions: {},
+	_IDStack: { State },
+	_usedIDs: { [ID]: number },
+	_stackIndex: number,
+	_cycleTick: number,
+	_widgetCount: number,
+	_lastWidget: Widget,
+	_nextWidgetId: ID,
+	SelectionImageObject: Frame,
+	parentInstance: BasePlayerGui,
+
+	_lastVDOM: { [ID]: Widget },
+	_VDOM: { [ID]: Widget },
+
+	Args: {},
+
+	_generateSelectionImageObject: () -> (),
+	_generateRootInstance: () -> (),
+	_deepCompare: ( t1: {}, t2: {} ) -> boolean,
+	_getID: (levelsToIgnore: number) -> ID,
+	SetNextWidgetID: (ID: ID) -> (),
+	_generateEmptyVDOM: () -> { [ID]: Widget },
+	_cycle: () -> (),
+	_GetParentWidget: () -> Widget,
+	_EventCall: (thisWidget: Widget, eventName: string) -> boolean,
+	ForceRefresh: () -> (),
+	_NoOp: () -> (),
+	WidgetConstructor: (type: string, widgetClass: WidgetClass) -> (),
+
+	UpdateGlobalConfig: (deltaStyle: { [any]: any }) -> (),
+	PushConfig: (deltaStyle: { [any]: any }) -> (),
+	PopConfig: () -> (),
+
+	State: (initialValue: any) -> (),
+	ComputatedState: (firstState: State, onChangeCallback: (firstState: any) -> (any)) -> State,
+	_widgetState: (thisWidget: Widget, stateName: string, initialValue: any) -> State,
+
+	Init: (parentInstance: BasePlayerGui?, eventConnection: (RBXScriptConnection | () -> {})?) -> (),
+	Connect: (callback: () -> ()) -> (),
+
+	_DiscardWidget: (widgetToDiscard: Widget) -> (),
+	_GenNewWidget: (widgetType: string, arguments: Arguments, widgetState: States?, ID: ID) -> Widget,
+	_Inset: (widgetType: string, args: { [number]: any }, widgetState: States?) -> Widget,
+	_ContinueWidget: (ID: ID, widgetType: string) -> Widget,
+	Append: (userInstance: GuiObject) -> (),
+
+	End: () -> (),
+	Text: (args: WidgetArguments) -> Widget,
+	TextColored: (args: WidgetArguments) -> Widget,
+	TextWrapped: (args: WidgetArguments) -> Widget,
+
+	Button: (args: WidgetArguments) -> Widget,
+	SmallButton: (args: WidgetArguments) -> Widget,
+	Checkbox: (args: WidgetArguments, state: States?) -> Widget,
+	RadioButton: (args: WidgetArguments, state: States?) -> Widget,
+
+	Separator: (args: WidgetArguments) -> Widget,
+	Indent: (args: WidgetArguments) -> Widget,
+	SameLine: (args: WidgetArguments) -> Widget,
+	Group: (args: WidgetArguments) -> Widget,
+	Selectable: (args: WidgetArguments, state: States?) -> Widget,
+
+	Tree: (args: WidgetArguments, state: States?) -> Widget,
+	CollapsingHeader: (args: WidgetArguments, state: States?) -> Widget,
+	
+	DragNum: (args: WidgetArguments, state: States?) -> Widget,
+	SliderNum: (args: WidgetArguments, state: States?) -> Widget,
+	InputNum: (args: WidgetArguments, state: States?) -> Widget,
+	InputText: (args: WidgetArguments, state: States?) -> Widget,
+	InputEnum: (args: WidgetArguments, state: States?, enumType: Enum) -> Widget,
+	Combo: (args: WidgetArguments, state: States?) -> Widget,
+	ComboArray: (args: WidgetArguments, state: States?, selectionArray: {any} ) -> Widget,
+	
+	Table: (args: WidgetArguments, state: States?) -> Widget,
+	NextColumn: () -> (),
+	SetColumnIndex: (columnIndex: number) -> (),
+	NextRow: () -> (),
+	
+	Window: (args: WidgetArguments, state: States?) -> Widget,
+	Tooltip: (args: WidgetArguments) -> Widget,
+	SetFocusedWindow: (thisWidget: Widget?) -> ()
+}
+
+return {}

--- a/src/client/Iris/Types.lua
+++ b/src/client/Iris/Types.lua
@@ -20,7 +20,7 @@ export type Events = { [string]: Event }
 export type Widget = {
 	ID: ID,
 	type: string,
-	state: State,
+	state: States,
 
 	parentWidget: Widget,
 	Instance: GuiObject,
@@ -29,7 +29,17 @@ export type Widget = {
 	ZIndex: number,
 
 	trackedEvents: {},
-	lastCycleTick: number
+	lastCycleTick: number,
+
+	isHoveredEvent: boolean,
+	lastClickedTick: number,
+	lastRightClickedTick: number,
+	lastClickedTime: number,
+	lastClickedPosition: Vector2,
+	lastDoubleClickedTick: number,
+	lastCtrlClickedTick: number,
+	lastCheckedTick: number,
+	lastUncheckedTick: number,
 }
 
 export type Argument = any
@@ -54,13 +64,53 @@ export type WidgetClass = {
 	ChildDiscarded: (thisWidget: Widget, thisChild: Widget) -> (),
 }
 
+export type WidgetUtility = {
+	GuiService: GuiService,
+	UserInputService: UserInputService,
+
+	ICONS: {
+		RIGHT_POINTING_TRIANGLE: string,
+        DOWN_POINTING_TRIANGLE: string,
+        MULTIPLICATION_SIGN: string,
+        BOTTOM_RIGHT_CORNER: string,
+        CHECK_MARK: string
+	},
+
+	findBestWindowPosForPopup: (refPos: Vector2, size: Vector2, outerMin: Vector2, outerMax: Vector2) -> Vector2,
+	isPosInsideRect: (pos: Vector2, rectMin: Vector2, rectMax: Vector2) -> boolean,
+	extend: (superClass: WidgetClass, subClass: WidgetClass) -> WidgetClass,
+	discardState: (thisWidget: Widget) -> (),
+
+	UIPadding: (Parent: GuiObject, PxPadding: Vector2) -> UIPadding,
+	UIListLayout: (Parent: GuiObject, FillDirection: Enum.FillDirection, Padding: UDim) -> UIListLayout,
+	UIStroke: (Parent: GuiObject, Thickness: number, Color: Color3, Transparency: number) -> UIStroke,
+	UICorner: (Parent: GuiObject, PxRounding: number) -> UICorner,
+	UISizeConstraint: (Parent: GuiObject, MinSize: Vector2, MaxSize: Vector2) -> UISizeConstraint,
+
+	applyTextStyle: (thisInstance: TextLabel | TextButton | TextBox) -> (),
+	applyInteractionHighlights: (Button: GuiButton, Highlightee: GuiObject, Colors: { [string]: any }) -> (),
+	applyInteractionHighlightsWithMultiHighlightee: (Button: GuiButton, Highlightees: { { GuiObject | { [string]: Color3 | number} } }) -> (),
+	applyTextInteractionHighlights: (Button: GuiButton, Highlightee: TextLabel | TextButton | TextBox, Colors: { [string]: any }) -> (),
+	applyFrameStyle: (thisInstance: GuiObject, forceNoPadding: boolean?, doubleyNoPadding: boolean?) -> (),
+
+	EVENTS: {
+		hover: (pathToHovered: (thisWidget: Widget) -> GuiObject) -> Event,
+		click: (pathToClicked: (thisWidget: Widget) -> GuiButton) -> Event,
+		rightClick: (pathToClicked: (thisWidget: Widget) -> GuiButton) -> Event,
+		doubleClick: (pathToClicked: (thisWidget: Widget) -> GuiButton) -> Event,
+		ctrlClick: (pathToClicked: (thisWidget: Widget) -> GuiButton) -> Event,
+	},
+
+	abstractButton: WidgetClass
+}
+
 export type Iris = {
 	_started: boolean,
 	_globalRefreshRequested: boolean,
 	_localRefreshActive: boolean,
 	_widgets: { [string]: WidgetClass },
-	_rootConfig: {},
-	_config: {},
+	_rootConfig: Config,
+	_config: Config,
 	_rootInstance: GuiObject,
 	_rootWidget: Widget,
 	_states: { [ID]: State },
@@ -146,6 +196,117 @@ export type Iris = {
 	Window: (args: WidgetArguments, state: States?) -> Widget,
 	Tooltip: (args: WidgetArguments) -> Widget,
 	SetFocusedWindow: (thisWidget: Widget?) -> ()
+}
+
+export type Config = {
+	TextColor: Color3,
+	TextTransparency: number,
+	TextDisabledColor: Color3,
+	TextDisabledTransparency: number,
+
+	BorderColor: Color3,
+	BorderActiveColor: Color3,
+	BorderTransparency: number,
+	BorderActiveTransparency: number,
+
+	WindowBgColor: Color3,
+	WindowBgTransparency: number,
+	ScrollbarGrabColor: Color3,
+	ScrollbarGrabTransparency: number,
+
+	TitleBgColor: Color3,
+	TitleBgTransparency: number,
+	TitleBgActiveColor: Color3,
+	TitleBgActiveTransparency: number,
+	TitleBgCollapsedColor: Color3,
+	TitleBgCollapsedTransparency: number,
+
+	MenubarBgColor: Color3,
+	MenubarBgTransparency: number,
+
+	FrameBgColor: Color3,
+	FrameBgTransparency: number,
+	FrameBgHoveredColor: Color3,
+	FrameBgHoveredTransparency: number,
+	FrameBgActiveColor: Color3,
+	FrameBgActiveTransparency: number,
+
+	ButtonColor: Color3,
+	ButtonTransparency: number,
+	ButtonHoveredColor: Color3,
+	ButtonHoveredTransparency: number,
+	ButtonActiveColor: Color3,
+	ButtonActiveTransparency: number,
+
+	SliderGrabColor: Color3,
+	SliderGrabTransparency: number,
+	SliderGrabActiveColor: Color3,
+	SliderGrabActiveTransparency: number,
+
+	HeaderColor: Color3,
+	HeaderTransparency: number,
+	HeaderHoveredColor: Color3,
+	HeaderHoveredTransparency: number,
+	HeaderActiveColor: Color3,
+	HeaderActiveTransparency: number,
+
+	SelectionImageObjectColor: Color3,
+	SelectionImageObjectTransparency: number,
+	SelectionImageObjectBorderColor: Color3,
+	SelectionImageObjectBorderTransparency: number,
+
+	TableBorderStrongColor: Color3,
+	TableBorderStrongTransparency: number,
+	TableBorderLightColor: Color3,
+	TableBorderLightTransparency: number,
+	TableRowBgColor: Color3,
+	TableRowBgTransparency: number,
+	TableRowBgAltColor: Color3,
+	TableRowBgAltTransparency: number,
+
+	NavWindowingHighlightColor: Color3,
+	NavWindowingHighlightTransparency: number,
+	NavWindowingDimBgColor: Color3,
+	NavWindowingDimBgTransparency: number,
+
+	SeparatorColor: Color3,
+	SeparatorTransparency: number,
+
+	CheckMarkColor: Color3,
+	CheckMarkTransparency: number,
+	
+	ItemWidth: UDim,
+	ContentWidth: UDim,
+
+	WindowPadding: Vector2,
+	WindowResizePadding: Vector2,
+	FramePadding: Vector2,
+	ItemSpacing: Vector2,
+	ItemInnerSpacing: Vector2,
+	CellPadding: Vector2,
+	DisplaySafeAreaPadding: Vector2,
+	IndentSpacing: number,
+
+	TextFont: Font,
+	TextSize: number,
+	FrameBorderSize: number,
+	FrameRounding: number,
+	GrabRounding: number,
+	WindowBorderSize: number,
+	WindowTitleAlign: Enum.LeftRight,
+	PopupBorderSize: number,
+	PopupRounding: number,
+	ScrollbarSize: number,
+	GrabMinSize: number,
+
+	UseScreenGUIs: boolean,
+	Parent: BasePlayerGui,
+	DisplayOrderOffset: number,
+	ZIndexOffset: number,
+
+	MouseDoubleClickTime: number,
+	MouseDoubleClickMaxDist: number,
+	MouseDragThreshold: number
 }
 
 return {}

--- a/src/client/Iris/Types.lua
+++ b/src/client/Iris/Types.lua
@@ -149,10 +149,10 @@ export type Iris = {
 	PopConfig: () -> (),
 
 	State: (initialValue: any) -> (),
-	ComputatedState: (firstState: State, onChangeCallback: (firstState: any) -> (any)) -> State,
+	ComputedState: (firstState: State, onChangeCallback: (firstState: any) -> (any)) -> State,
 	_widgetState: (thisWidget: Widget, stateName: string, initialValue: any) -> State,
 
-	Init: (parentInstance: BasePlayerGui?, eventConnection: (RBXScriptConnection | () -> {})?) -> (),
+	Init: (parentInstance: BasePlayerGui?, eventConnection: (RBXScriptConnection | () -> {})?) -> Iris,
 	Connect: (self: Iris, callback: () -> ()) -> (),
 
 	_DiscardWidget: (widgetToDiscard: Widget) -> (),

--- a/src/client/Iris/config.lua
+++ b/src/client/Iris/config.lua
@@ -178,7 +178,7 @@ local TemplateConfig = {
         DisplaySafeAreaPadding = Vector2.new(0, 0),
         IndentSpacing = 21,
 
-        TextFont = Enum.Font.Code,
+        TextFont = Font.fromEnum(Enum.Font.Code),
         TextSize = 13,
         FrameBorderSize = 0,
         FrameRounding = 0,
@@ -203,7 +203,7 @@ local TemplateConfig = {
         DisplaySafeAreaPadding = Vector2.new(8, 8),
         IndentSpacing = 25,
 
-        TextFont = Enum.Font.Ubuntu,
+        TextFont = Font.fromEnum(Enum.Font.Ubuntu),
         TextSize = 15,
         FrameBorderSize = 1,
         FrameRounding = 4,

--- a/src/client/Iris/config.lua
+++ b/src/client/Iris/config.lua
@@ -28,6 +28,9 @@ local TemplateConfig = {
         TitleBgCollapsedColor = Color3.fromRGB(0, 0, 0),
         TitleBgCollapsedTransparency = 0.5,
 
+		MenubarBgColor = Color3.fromRGB(36, 36, 36),
+		MenubarBgTransparency = 0,
+
         FrameBgColor = Color3.fromRGB(41, 74, 122),
         FrameBgTransparency = 0.46,
         FrameBgHoveredColor = Color3.fromRGB(66, 150, 250),
@@ -103,6 +106,9 @@ local TemplateConfig = {
         TitleBgActiveTransparency = 0,
         TitleBgCollapsedColor = Color3.fromRGB(255, 255, 255),
         TitleBgCollapsedTransparency = 0.5,
+
+		MenubarBgColor = Color3.fromRGB(219, 219, 219),
+		MenubarBgTransparency = 0,
 
         ScrollbarGrabColor = Color3.fromRGB(96, 96, 96),
         ScrollbarGrabTransparency = 0,

--- a/src/client/Iris/demoWindow.lua
+++ b/src/client/Iris/demoWindow.lua
@@ -218,7 +218,7 @@ return function(Iris)
 
         Combo = function()
             Iris.Tree({"Combo"})
-                Iris.PushConfig({ContentWidth = UDim.new(0, 350)})
+                Iris.PushConfig({ContentWidth = UDim.new(1, -120)})
                     local sharedComboIndex = Iris.State("No Selection")
                     Iris.SameLine()
                         local NoPreview = Iris.Checkbox({"No Preview"})
@@ -366,6 +366,22 @@ return function(Iris)
                     {"Text: string",      "opened: boolean",  "index: any"       },
                     {"NoButton: boolean", "closed: boolean",  "isOpened: boolean"},
                     {"NoPreview: boolean","clicked: boolean", ""                 }
+                })
+            Iris.End()
+            Iris.CollapsingHeader({"Iris.ComboArray"})
+                parse2DArray({
+                    {"Arguments",	      "Events",           "States",			   "Extra"		   },	
+                    {"Text: string",      "opened: boolean",  "index: any",		   "array: { any }"},
+                    {"NoButton: boolean", "closed: boolean",  "isOpened: boolean", ""			   },
+                    {"NoPreview: boolean","clicked: boolean", "",				   ""			   }
+                })
+            Iris.End()
+            Iris.CollapsingHeader({"Iris.ComboEnum"})
+                parse2DArray({
+                    {"Arguments",	      "Events",           "States",			   "Extra"	   },	
+                    {"Text: string",      "opened: boolean",  "index: any",		   "enum: Enum"},
+                    {"NoButton: boolean", "closed: boolean",  "isOpened: boolean", ""		   },
+                    {"NoPreview: boolean","clicked: boolean", "",				   ""		   }
                 })
             Iris.End()
             Iris.CollapsingHeader({"Iris.Tree"})
@@ -1037,6 +1053,7 @@ return function(Iris)
 		Iris.CollapsingHeader({"Widget Layout"})
 			Iris.Tree({"Content Width"})
 				local value = Iris.State(50)
+				local index = Iris.State(Enum.Axis.X)
 
 				Iris.Text({"The Content Width is a size property which determines the width of input fields."})
 				Iris.SameLine()
@@ -1054,6 +1071,7 @@ return function(Iris)
 				Iris.End()
 				Iris.PushConfig({ContentWidth = UDim.new(0, 150)})
 					Iris.DragNum({"number", 1, 0, 100}, {number = value})
+					Iris.InputEnum({"axis"}, {index = index}, Enum.Axis)
 				Iris.PopConfig()
 
 				Iris.SameLine()
@@ -1062,6 +1080,7 @@ return function(Iris)
 				Iris.End()
 				Iris.PushConfig({ContentWidth = UDim.new(0.5, 0)})
 					Iris.DragNum({"number", 1, 0, 100}, {number = value})
+					Iris.InputEnum({"axis"}, {index = index}, Enum.Axis)
 				Iris.PopConfig()
 
 				Iris.SameLine()
@@ -1070,6 +1089,7 @@ return function(Iris)
 				Iris.End()
 				Iris.PushConfig({ContentWidth = UDim.new(1, -150)})
 					Iris.DragNum({"number", 1, 0, 100}, {number = value})
+					Iris.InputEnum({"axis"}, {index = index}, Enum.Axis)
 				Iris.PopConfig()
 			Iris.End()
 		Iris.End()

--- a/src/client/Iris/init.lua
+++ b/src/client/Iris/init.lua
@@ -1072,13 +1072,13 @@ end
 
 --- @prop InputVector2 Widget
 --- @within Widgets
-Iris.InputVector2 = function(args, state)
+Iris.InputVector2 = function(args: Types.WidgetArguments, state: Types.States?): Types.Widget
     return Iris._Insert("InputVector2", args, state)
 end
 
 --- @prop InputVector3 Widget
 --- @within Widgets
-Iris.InputVector3 = function(args, state)
+Iris.InputVector3 = function(args: Types.WidgetArguments, state: Types.States?): Types.Widget
     return Iris._Insert("InputVector3", args, state)
 end
 

--- a/src/client/Iris/init.lua
+++ b/src/client/Iris/init.lua
@@ -510,7 +510,7 @@ end
 --- :::tip
 --- Want to stop Iris from rendering and consuming performance, but keep all the Iris code? simply comment out the `Iris.Init()` line in your codebase.
 --- :::
-function Iris.Init(parentInstance: BasePlayerGui?, eventConnection: (RBXScriptSignal | () -> {})?)
+function Iris.Init(parentInstance: BasePlayerGui?, eventConnection: (RBXScriptSignal | () -> {})?): Types.Iris
 	if parentInstance == nil then
 		-- coalesce to playerGui
 		parentInstance = game:GetService("Players").LocalPlayer:WaitForChild("PlayerGui")

--- a/src/client/Iris/init.lua
+++ b/src/client/Iris/init.lua
@@ -1072,12 +1072,50 @@ end
 
 --- @prop InputVector2 Widget
 --- @within Widgets
+--- A field which allows for the input of a Vector2.
+---
+--- ```json 
+--- hasChildren: false,
+--- hasState: true,
+--- Arguments: {
+---     Text: string,
+---     Increment: Vector2,
+---     Min: Vector2,
+---     Max: Vector2,
+---     Format: string
+--- },
+--- Events: {
+---     numberChanged: boolean
+--- },
+--- States: {
+---     number: Vector2
+--- }
+--- ```
 Iris.InputVector2 = function(args: Types.WidgetArguments, state: Types.States?): Types.Widget
     return Iris._Insert("InputVector2", args, state)
 end
 
 --- @prop InputVector3 Widget
 --- @within Widgets
+--- A field which allows for the input of a Vector3.
+---
+--- ```json 
+--- hasChildren: false,
+--- hasState: true,
+--- Arguments: {
+---     Text: string,
+---     Increment: Vector3,
+---     Min: Vector3,
+---     Max: Vector3,
+---     Format: string
+--- },
+--- Events: {
+---     numberChanged: boolean
+--- },
+--- States: {
+---     number: Vector3
+--- }
+--- ```
 Iris.InputVector3 = function(args: Types.WidgetArguments, state: Types.States?): Types.Widget
     return Iris._Insert("InputVector3", args, state)
 end
@@ -1113,22 +1151,107 @@ end
 
 --- @prop Selectable Widget
 --- @within Widgets
+--- An object which can be selected.
+---
+--- ```json 
+--- hasChildren: false,
+--- hasState: true,
+--- Arguments: {
+---     Text: string,
+---     Index: any,
+---     NoClick: boolean
+--- },
+--- Events: {
+---     selected: boolean,
+--- 	unselected: boolean,
+--- 	active: boolean
+--- },
+--- States: {
+---     index: any
+--- }
+--- ```
 Iris.Selectable = function(args: Types.WidgetArguments, state: Types.States?): Types.Widget
 	return Iris._Insert("Selectable", args, state)
 end
 
 --- @prop Combo Widget
 --- @within Widgets
+--- A selection box to choose a value from a range of values.
+---
+--- ```json 
+--- hasChildren: true,
+--- hasState: true,
+--- Arguments: {
+---     Text: string,
+--- 	NoButton: boolean,
+--- 	NoPreview: boolean
+--- },
+--- Events: {
+---     opened: boolean,
+--- 	closed: boolean,
+--- 	clicked: boolean
+--- },
+--- States: {
+---     index: any,
+--- 	isOpened: boolean
+--- }
+--- ```
 Iris.Combo = function(args: Types.WidgetArguments, state: Types.States?): Types.Widget
 	return Iris._Insert("Combo", args, state)
 end
 
 --- @prop ComboArray Widget
 --- @within Widgets
+--- A selection box to choose a value from an array.
+---
+--- ```json 
+--- hasChildren: true,
+--- hasState: true,
+--- Arguments: {
+---     Text: string,
+--- 	NoButton: boolean,
+--- 	NoPreview: boolean
+--- },
+--- Events: {
+---     opened: boolean,
+--- 	closed: boolean,
+--- 	clicked: boolean
+--- },
+--- States: {
+---     index: any,
+--- 	isOpened: boolean
+--- },
+--- Extra: {
+--- 	selectionArray: { any }	
+--- }
+--- ```
 Iris.ComboArray = Iris.ComboArray
 
 --- @prop InputEnum Widget
 --- @within Widgets
+--- A selection box to choose a value from an Enum.
+---
+--- ```json 
+--- hasChildren: true,
+--- hasState: true,
+--- Arguments: {
+---     Text: string,
+--- 	NoButton: boolean,
+--- 	NoPreview: boolean
+--- },
+--- Events: {
+---     opened: boolean,
+--- 	closed: boolean,
+--- 	clicked: boolean
+--- },
+--- States: {
+---     index: any,
+--- 	isOpened: boolean
+--- },
+--- Extra: {
+--- 	enumType: Enum	
+--- }
+--- ```
 Iris.InputEnum = Iris.InputEnum
 
 --- @prop Table Widget

--- a/src/client/Iris/widgets/Button.lua
+++ b/src/client/Iris/widgets/Button.lua
@@ -1,4 +1,6 @@
-return function(Iris, widgets)
+local Types = require(script.Parent.Parent.Types)
+
+return function(Iris: Types.Iris, widgets: Types.WidgetUtility)
     local abstractButton = {
         hasState = false,
         hasChildren = false,
@@ -6,24 +8,24 @@ return function(Iris, widgets)
             ["Text"] = 1
         },
         Events = {
-            ["clicked"] = widgets.EVENTS.click(function(thisWidget)
+            ["clicked"] = widgets.EVENTS.click(function(thisWidget: Types.Widget)
                 return thisWidget.Instance
             end),
-            ["rightClicked"] = widgets.EVENTS.rightClick(function(thisWidget)
+            ["rightClicked"] = widgets.EVENTS.rightClick(function(thisWidget: Types.Widget)
                 return thisWidget.Instance
             end),
-            ["doubleClicked"] = widgets.EVENTS.doubleClick(function(thisWidget)
+            ["doubleClicked"] = widgets.EVENTS.doubleClick(function(thisWidget: Types.Widget)
                 return thisWidget.Instance
             end),
-            ["ctrlClicked"] = widgets.EVENTS.ctrlClick(function(thisWidget)
+            ["ctrlClicked"] = widgets.EVENTS.ctrlClick(function(thisWidget: Types.Widget)
                 return thisWidget.Instance
             end),
-            ["hovered"] = widgets.EVENTS.hover(function(thisWidget)
+            ["hovered"] = widgets.EVENTS.hover(function(thisWidget: Types.Widget)
                 return thisWidget.Instance
             end)
         },
-        Generate = function(thisWidget)
-            local Button = Instance.new("TextButton")
+        Generate = function(thisWidget: Types.Widget): TextButton
+            local Button: TextButton = Instance.new("TextButton")
             Button.Size = UDim2.fromOffset(0, 0)
             Button.BackgroundColor3 = Iris._config.ButtonColor
             Button.BackgroundTransparency = Iris._config.ButtonTransparency
@@ -48,31 +50,31 @@ return function(Iris, widgets)
     
             return Button
         end,
-        Update = function(thisWidget)
-            local Button = thisWidget.Instance
+        Update = function(thisWidget: Types.Widget)
+            local Button = thisWidget.Instance :: TextButton
             Button.Text = thisWidget.arguments.Text or "Button"
         end,
-        Discard = function(thisWidget)
+        Discard = function(thisWidget: Types.Widget)
             thisWidget.Instance:Destroy()
         end
-    }
+    } :: Types.WidgetClass
     widgets.abstractButton = abstractButton
     
     Iris.WidgetConstructor("Button", widgets.extend(abstractButton, {
-        Generate = function(thisWidget)
-            local Button = abstractButton.Generate(thisWidget)
+        Generate = function(thisWidget: Types.Widget): TextButton
+            local Button: TextButton = abstractButton.Generate(thisWidget)
             Button.Name = "Iris_Button"
     
             return Button
         end
-    }))
+    } :: Types.WidgetClass))
     
     Iris.WidgetConstructor("SmallButton", widgets.extend(abstractButton, {
-        Generate = function(thisWidget)
-            local SmallButton = abstractButton.Generate(thisWidget)
+        Generate = function(thisWidget): TextButton
+            local SmallButton = abstractButton.Generate(thisWidget) :: TextButton
             SmallButton.Name = "Iris_SmallButton"
     
-            local uiPadding = SmallButton.UIPadding
+            local uiPadding = SmallButton.UIPadding :: UIPadding
             uiPadding.PaddingLeft = UDim.new(0, 2)
             uiPadding.PaddingRight = UDim.new(0, 2)
             uiPadding.PaddingTop = UDim.new(0, 0)
@@ -80,5 +82,5 @@ return function(Iris, widgets)
     
             return SmallButton
         end
-    }))
+    } :: Types.WidgetClass))
 end

--- a/src/client/Iris/widgets/Checkbox.lua
+++ b/src/client/Iris/widgets/Checkbox.lua
@@ -1,4 +1,6 @@
-return function(Iris, widgets)
+local Types = require(script.Parent.Parent.Types)
+
+return function(Iris: Types.Iris, widgets: Types.WidgetUtility)
     Iris.WidgetConstructor("Checkbox", {
         hasState = true,
         hasChildren = false,
@@ -7,27 +9,27 @@ return function(Iris, widgets)
         },
         Events = {
             ["checked"] = {
-                ["Init"] = function(thisWidget)
+                ["Init"] = function(thisWidget: Types.Widget)
 
                 end,
-                ["Get"] = function(thisWidget)
+                ["Get"] = function(thisWidget: Types.Widget): boolean
                     return thisWidget.lastCheckedTick == Iris._cycleTick
                 end
             },
             ["unchecked"] = {
-                ["Init"] = function(thisWidget)
+                ["Init"] = function(thisWidget: Types.Widget)
 
                 end,
-                ["Get"] = function(thisWidget)
+                ["Get"] = function(thisWidget: Types.Widget): boolean
                     return thisWidget.lastUncheckedTick == Iris._cycleTick
                 end
             },
-            ["hovered"] = widgets.EVENTS.hover(function(thisWidget)
+            ["hovered"] = widgets.EVENTS.hover(function(thisWidget: Types.Widget): GuiObject
                 return thisWidget.Instance
             end)
         },
-        Generate = function(thisWidget)
-            local Checkbox = Instance.new("TextButton")
+        Generate = function(thisWidget: Types.Widget)
+            local Checkbox: TextButton = Instance.new("TextButton")
             Checkbox.Name = "Iris_Checkbox"
             Checkbox.BackgroundTransparency = 1
             Checkbox.BorderSizePixel = 0
@@ -38,7 +40,7 @@ return function(Iris, widgets)
             Checkbox.AutoButtonColor = false
             Checkbox.LayoutOrder = thisWidget.ZIndex
 
-            local CheckboxBox = Instance.new("TextLabel")
+            local CheckboxBox: TextLabel = Instance.new("TextLabel")
             CheckboxBox.Name = "CheckboxBox"
             CheckboxBox.AutomaticSize = Enum.AutomaticSize.None
             local checkboxSize = Iris._config.TextSize + 2 * Iris._config.FramePadding.Y
@@ -64,11 +66,11 @@ return function(Iris, widgets)
             })
 
             Checkbox.MouseButton1Click:Connect(function()
-                local wasChecked = thisWidget.state.isChecked.value
+                local wasChecked: boolean = thisWidget.state.isChecked.value
                 thisWidget.state.isChecked:set(not wasChecked)
             end)
 
-            local TextLabel = Instance.new("TextLabel")
+            local TextLabel: TextLabel = Instance.new("TextLabel")
             TextLabel.Name = "TextLabel"
             widgets.applyTextStyle(TextLabel)
             TextLabel.Position = UDim2.new(0,checkboxSize + Iris._config.ItemInnerSpacing.X, 0.5, 0)
@@ -82,20 +84,20 @@ return function(Iris, widgets)
 
             return Checkbox
         end,
-        Update = function(thisWidget)
+        Update = function(thisWidget: Types.Widget)
             thisWidget.Instance.TextLabel.Text = thisWidget.arguments.Text or "Checkbox"
         end,
-        Discard = function(thisWidget)
+        Discard = function(thisWidget: Types.Widget)
             thisWidget.Instance:Destroy()
             widgets.discardState(thisWidget)
         end,
-        GenerateState = function(thisWidget)
+        GenerateState = function(thisWidget: Types.Widget)
             if thisWidget.state.isChecked == nil then
                 thisWidget.state.isChecked = Iris._widgetState(thisWidget, "checked", false)
             end
         end,
-        UpdateState = function(thisWidget)
-            local Checkbox = thisWidget.Instance.CheckboxBox
+        UpdateState = function(thisWidget: Types.Widget)
+            local Checkbox = thisWidget.Instance.CheckboxBox :: TextLabel
             if thisWidget.state.isChecked.value then
                 Checkbox.Text = widgets.ICONS.CHECK_MARK
                 thisWidget.lastCheckedTick = Iris._cycleTick + 1
@@ -104,5 +106,5 @@ return function(Iris, widgets)
                 thisWidget.lastUncheckedTick = Iris._cycleTick + 1
             end
         end
-    })
+    } :: Types.WidgetClass)
 end

--- a/src/client/Iris/widgets/Combo.lua
+++ b/src/client/Iris/widgets/Combo.lua
@@ -133,14 +133,13 @@ return function(Iris, widgets)
 
     local function UpdateChildContainerTransform(thisWidget)
         local Iris_Combo = thisWidget.Instance
-        local ComboLine = Iris_Combo.ComboLine
-        local PreviewContainer = ComboLine.PreviewContainer
+        local PreviewContainer = Iris_Combo.PreviewContainer
         local PreviewLabel = PreviewContainer.PreviewLabel
         local ChildContainer = thisWidget.ChildContainer
 
         local ChildContainerBorderSize = Iris._config.PopupBorderSize
         local ChildContainerHeight = thisWidget.LabelHeight * math.min(thisWidget.NumChildrenForSize, 8) - 2 * ChildContainerBorderSize
-        local ChildContainerWidth = UDim.new(thisWidget.ContentWidth.Scale, thisWidget.ContentWidth.Offset - 2 * ChildContainerBorderSize)
+        local ChildContainerWidth = UDim.new(0, PreviewContainer.AbsoluteSize.X - 2 * ChildContainerBorderSize)
         ChildContainer.Size = UDim2.new(ChildContainerWidth, UDim.new(0, ChildContainerHeight))
 
         local ScreenSize = ChildContainer.Parent.AbsoluteSize
@@ -211,29 +210,18 @@ return function(Iris, widgets)
 
             local Combo = Instance.new("Frame")
             Combo.Name = "Iris_Combo"
-            Combo.Size = UDim2.fromOffset(0, thisWidget.LabelHeight)
-            Combo.AutomaticSize = Enum.AutomaticSize.X
+            Combo.Size = UDim2.fromScale(1, 0)
+            Combo.AutomaticSize = Enum.AutomaticSize.Y
             Combo.BackgroundTransparency = 1
             Combo.BorderSizePixel = 0
             Combo.ZIndex = thisWidget.ZIndex
             Combo.LayoutOrder = thisWidget.ZIndex
-
-            local ComboLine = Instance.new("Frame")
-            ComboLine.Name = "ComboLine"
-            ComboLine.Size = UDim2.fromScale(0, 1)
-            ComboLine.AutomaticSize = Enum.AutomaticSize.X
-            ComboLine.BackgroundTransparency = 1
-            ComboLine.BorderSizePixel = 0
-            ComboLine.ZIndex = thisWidget.ZIndex + 1
-            ComboLine.LayoutOrder = thisWidget.ZIndex + 1
-            widgets.UIListLayout(ComboLine, Enum.FillDirection.Horizontal, UDim.new(0, Iris._config.ItemInnerSpacing.Y))
-
-            ComboLine.Parent = Combo
+            widgets.UIListLayout(Combo, Enum.FillDirection.Horizontal, UDim.new(0, Iris._config.ItemInnerSpacing.Y))
 
             local PreviewContainer = Instance.new("TextButton")
             PreviewContainer.Name = "PreviewContainer"
-            PreviewContainer.Size = UDim2.fromScale(0, 1)
-            PreviewContainer.AutomaticSize = Enum.AutomaticSize.X
+            PreviewContainer.Size = UDim2.new(Iris._config.ContentWidth, UDim.new(0, 0))
+            PreviewContainer.AutomaticSize = Enum.AutomaticSize.Y
             widgets.applyFrameStyle(PreviewContainer, true, true)
             PreviewContainer.BackgroundTransparency = 1
             PreviewContainer.ZIndex = thisWidget.ZIndex + 2
@@ -242,11 +230,11 @@ return function(Iris, widgets)
             PreviewContainer.AutoButtonColor = false
             widgets.UIListLayout(PreviewContainer, Enum.FillDirection.Horizontal, UDim.new(0, 0))
 
-            PreviewContainer.Parent = ComboLine
+            PreviewContainer.Parent = Combo
 
             local PreviewLabel = Instance.new("TextLabel")
             PreviewLabel.Name = "PreviewLabel"
-            PreviewLabel.Size = UDim2.new(Iris._config.ContentWidth, UDim.new(0, 0))
+            PreviewLabel.Size = UDim2.new(1, 0, 0, 0)
             PreviewLabel.BackgroundColor3 = Iris._config.FrameBgColor
             PreviewLabel.BackgroundTransparency = Iris._config.FrameBgTransparency
             PreviewLabel.BorderSizePixel = 0
@@ -268,6 +256,7 @@ return function(Iris, widgets)
             DropdownButton.ZIndex = thisWidget.ZIndex + 4
             DropdownButton.LayoutOrder = thisWidget.ZIndex + 4
             widgets.applyTextStyle(DropdownButton)
+            DropdownButton.TextXAlignment = Enum.TextXAlignment.Center
 
             DropdownButton.Parent = PreviewContainer
 
@@ -318,7 +307,7 @@ return function(Iris, widgets)
             TextLabel.AutomaticSize = Enum.AutomaticSize.X
             widgets.applyTextStyle(TextLabel)
 
-            TextLabel.Parent = ComboLine
+            TextLabel.Parent = Combo
 
             local ChildContainer = Instance.new("ScrollingFrame")
             ChildContainer.Name = "ChildContainer"
@@ -360,30 +349,30 @@ return function(Iris, widgets)
         end,
         Update = function(thisWidget)
             local Iris_Combo = thisWidget.Instance
-            local ComboLine = Iris_Combo.ComboLine
-            local PreviewContainer = ComboLine.PreviewContainer
+            local PreviewContainer = Iris_Combo.PreviewContainer
             local PreviewLabel = PreviewContainer.PreviewLabel
             local DropdownButton = PreviewContainer.DropdownButton
-            local TextLabel = ComboLine.TextLabel
-            local ChildContainer = thisWidget.ChildContainer
-
-            DropdownButton.TextXAlignment = Enum.TextXAlignment.Center
+            local TextLabel = Iris_Combo.TextLabel
 
             TextLabel.Text = thisWidget.arguments.Text or "Combo"
             
             if thisWidget.arguments.NoButton then
                 DropdownButton.Visible = false
-                PreviewLabel.Size = UDim2.new(Iris._config.ContentWidth, UDim.new(0, 0))
+                PreviewLabel.Size = UDim2.new(1, 0, 0, 0)
             else
                 DropdownButton.Visible = true
                 local DropdownButtonSize = Iris._config.TextSize + 2 * Iris._config.FramePadding.Y
-                PreviewLabel.Size = UDim2.new(UDim.new(Iris._config.ContentWidth.Scale, Iris._config.ContentWidth.Offset - DropdownButtonSize), UDim.new(0, 0))
+                PreviewLabel.Size = UDim2.new(1, - DropdownButtonSize, 0, 0)
             end
 
             if thisWidget.arguments.NoPreview then
                 PreviewLabel.Visible = false
+				PreviewContainer.Size = UDim2.new(0, 0, 0, 0)
+				PreviewContainer.AutomaticSize = Enum.AutomaticSize.X
             else
                 PreviewLabel.Visible = true
+				PreviewContainer.Size = UDim2.new(Iris._config.ContentWidth, UDim.new(0, 0))
+				PreviewContainer.AutomaticSize = Enum.AutomaticSize.Y
             end
         end,
         ChildAdded = function(thisWidget, thisChild)
@@ -418,11 +407,9 @@ return function(Iris, widgets)
         end,
         UpdateState = function(thisWidget)
             local Iris_Combo = thisWidget.Instance
-            local ComboLine = Iris_Combo.ComboLine
-            local PreviewContainer = ComboLine.PreviewContainer
+            local PreviewContainer = Iris_Combo.PreviewContainer
             local PreviewLabel = PreviewContainer.PreviewLabel
             local DropdownButton = PreviewContainer.DropdownButton
-            local TextLabel = ComboLine.TextLabel
             local ChildContainer = thisWidget.ChildContainer
 
             -- ImGui also does not do this, and the Arrow is always facing down

--- a/src/client/Iris/widgets/Tree.lua
+++ b/src/client/Iris/widgets/Tree.lua
@@ -242,6 +242,7 @@ return function(Iris, widgets)
             Collapse.AutomaticSize = Enum.AutomaticSize.Y
             Collapse.Text = ""
             Collapse.AutoButtonColor = false
+			Collapse.ClipsDescendants = true
             Collapse.Parent = Header
     
             widgets.UIPadding(Collapse, Vector2.new(2 * Iris._config.FramePadding.X, Iris._config.FramePadding.Y)) -- we add a custom padding because it extends on both sides

--- a/src/client/Iris/widgets/Window.lua
+++ b/src/client/Iris/widgets/Window.lua
@@ -439,7 +439,7 @@ return function(Iris, widgets)
             ChildContainer.Position = UDim2.fromOffset(0, 0)
             ChildContainer.BorderSizePixel = 0
             ChildContainer.ZIndex = thisWidget.ZIndex + 2
-            ChildContainer.LayoutOrder = thisWidget.ZIndex + 2
+            ChildContainer.LayoutOrder = thisWidget.ZIndex + 3
             ChildContainer.AutomaticSize = Enum.AutomaticSize.None
             ChildContainer.Size = UDim2.fromScale(1, 1)
             ChildContainer.Selectable = false

--- a/src/client/Iris/widgets/init.lua
+++ b/src/client/Iris/widgets/init.lua
@@ -1,6 +1,8 @@
-local widgets = {}
+local Types = require(script.Parent.Types)
 
-return function(Iris)
+local widgets = {} :: Types.WidgetUtility
+
+return function(Iris: Types.Iris)
 
     widgets.GuiService = game:GetService("GuiService")
     widgets.UserInputService = game:GetService("UserInputService")
@@ -13,8 +15,8 @@ return function(Iris)
         CHECK_MARK = "\u{2713}" -- curved shape, closest we can get to ImGui Checkmarks
     }
 
-    function widgets.findBestWindowPosForPopup(refPos, size, outerMin, outerMax)
-        local CURSOR_OFFSET_DIST = 20
+    function widgets.findBestWindowPosForPopup(refPos: Vector2, size: Vector2, outerMin: Vector2, outerMax: Vector2): Vector2
+        local CURSOR_OFFSET_DIST: number = 20
         
         if refPos.X + size.X + CURSOR_OFFSET_DIST > outerMax.X then
             if refPos.Y + size.Y + CURSOR_OFFSET_DIST > outerMax.Y then
@@ -29,27 +31,27 @@ return function(Iris)
             refPos += Vector2.new(CURSOR_OFFSET_DIST, 0)
         end
 
-        local clampedPos = Vector2.new(
+        local clampedPos: Vector2 = Vector2.new(
             math.max(math.min(refPos.X + size.X, outerMax.X) - size.X, outerMin.X),
             math.max(math.min(refPos.Y + size.Y, outerMax.Y) - size.Y, outerMin.Y)
         )
         return clampedPos
     end
 
-    function widgets.isPosInsideRect(pos, rectMin, rectMax)
+    function widgets.isPosInsideRect(pos: Vector2, rectMin: Vector2, rectMax: Vector2): boolean
         return pos.X > rectMin.X and pos.X < rectMax.X and pos.Y > rectMin.Y and pos.Y < rectMax.Y
     end
 
-    function widgets.extend(superClass, subClass)
-        local newClass = table.clone(superClass)
-        for i, v in subClass do
-            newClass[i] = v
+    function widgets.extend(superClass: Types.WidgetClass, subClass: Types.WidgetClass): Types.WidgetClass
+        local newClass: Types.WidgetClass = table.clone(superClass)
+        for index: string, value: any in subClass do
+            newClass[index] = value
         end
         return newClass
     end
 
-    function widgets.UIPadding(Parent, PxPadding)
-        local UIPaddingInstance = Instance.new("UIPadding")
+    function widgets.UIPadding(Parent: GuiObject, PxPadding: Vector2): UIPadding
+        local UIPaddingInstance: UIPadding = Instance.new("UIPadding")
         UIPaddingInstance.PaddingLeft = UDim.new(0, PxPadding.X)
         UIPaddingInstance.PaddingRight = UDim.new(0, PxPadding.X)
         UIPaddingInstance.PaddingTop = UDim.new(0, PxPadding.Y)
@@ -58,8 +60,8 @@ return function(Iris)
         return UIPaddingInstance
     end
 
-    function widgets.UIListLayout(Parent, FillDirection, Padding)
-        local UIListLayoutInstance = Instance.new("UIListLayout")
+    function widgets.UIListLayout(Parent: GuiObject, FillDirection: Enum.FillDirection, Padding: UDim): UIListLayout
+        local UIListLayoutInstance: UIListLayout = Instance.new("UIListLayout")
         UIListLayoutInstance.SortOrder = Enum.SortOrder.LayoutOrder
         UIListLayoutInstance.Padding = Padding
         UIListLayoutInstance.FillDirection = FillDirection
@@ -67,8 +69,8 @@ return function(Iris)
         return UIListLayoutInstance
     end
 
-    function widgets.UIStroke(Parent, Thickness, Color, Transparency)
-        local UIStrokeInstance = Instance.new("UIStroke")
+    function widgets.UIStroke(Parent: GuiObject, Thickness: number, Color: Color3, Transparency: number): UIStroke
+        local UIStrokeInstance: UIStroke = Instance.new("UIStroke")
         UIStrokeInstance.Thickness = Thickness
         UIStrokeInstance.Color = Color
         UIStrokeInstance.Transparency = Transparency
@@ -76,15 +78,15 @@ return function(Iris)
         return UIStrokeInstance
     end
 
-    function widgets.UICorner(Parent, PxRounding)
-        local UICornerInstance = Instance.new("UICorner")
+    function widgets.UICorner(Parent: GuiObject, PxRounding: number): UICorner
+        local UICornerInstance: UICorner = Instance.new("UICorner")
         UICornerInstance.CornerRadius = UDim.new(PxRounding ~= nil and 0 or 1, PxRounding or 0)
         UICornerInstance.Parent = Parent
         return UICornerInstance
     end
 
-    function widgets.UISizeConstraint(Parent, MinSize, MaxSize)
-        local UISizeConstraintInstance = Instance.new("UISizeConstraint")
+    function widgets.UISizeConstraint(Parent: GuiObject, MinSize: Vector2, MaxSize: Vector2): UISizeConstraint
+        local UISizeConstraintInstance: UISizeConstraint = Instance.new("UISizeConstraint")
         UISizeConstraintInstance.MinSize = MinSize or UISizeConstraintInstance.MinSize -- made these optional
         UISizeConstraintInstance.MaxSize = MaxSize or UISizeConstraintInstance.MaxSize
         UISizeConstraintInstance.Parent = Parent
@@ -93,8 +95,8 @@ return function(Iris)
 
     -- below uses Iris
 
-    function widgets.applyTextStyle(thisInstance)
-        thisInstance.Font = Iris._config.TextFont
+    function widgets.applyTextStyle(thisInstance: TextLabel | TextButton | TextBox)
+        thisInstance.FontFace = Iris._config.TextFont
         thisInstance.TextSize = Iris._config.TextSize
         thisInstance.TextColor3 = Iris._config.TextColor
         thisInstance.TextTransparency = Iris._config.TextTransparency
@@ -104,8 +106,8 @@ return function(Iris)
         thisInstance.RichText = false
     end
 
-    function widgets.applyInteractionHighlights(Button, Highlightee, Colors)
-        local exitedButton = false
+    function widgets.applyInteractionHighlights(Button: GuiButton, Highlightee: GuiObject, Colors: { [string]: any })
+        local exitedButton: boolean = false
         Button.MouseEnter:Connect(function()
             Highlightee.BackgroundColor3 = Colors.ButtonHoveredColor
             Highlightee.BackgroundTransparency = Colors.ButtonHoveredTransparency
@@ -120,7 +122,7 @@ return function(Iris)
             exitedButton = true
         end)
 
-        Button.InputBegan:Connect(function(input)
+        Button.InputBegan:Connect(function(input: InputObject)
             if not (input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Gamepad1) then
                 return
             end
@@ -128,7 +130,7 @@ return function(Iris)
             Highlightee.BackgroundTransparency = Colors.ButtonActiveTransparency
         end)
 
-        Button.InputEnded:Connect(function(input)
+        Button.InputEnded:Connect(function(input: InputObject)
             if not (input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Gamepad1) or exitedButton then
                 return
             end
@@ -145,8 +147,8 @@ return function(Iris)
         Button.SelectionImageObject = Iris.SelectionImageObject
     end
 
-    function widgets.applyInteractionHighlightsWithMultiHighlightee(Button, Highlightees)
-        local exitedButton = false
+    function widgets.applyInteractionHighlightsWithMultiHighlightee(Button: GuiButton, Highlightees: { { GuiObject | { [string]: Color3 | number} } })
+        local exitedButton: boolean = false
         Button.MouseEnter:Connect(function()
             for _, Highlightee in Highlightees do
                 Highlightee[1].BackgroundColor3 = Highlightee[2].ButtonHoveredColor
@@ -165,7 +167,7 @@ return function(Iris)
             end
         end)
 
-        Button.InputBegan:Connect(function(input)
+        Button.InputBegan:Connect(function(input: InputObject)
             if not (input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Gamepad1) then
                 return
             end
@@ -175,7 +177,7 @@ return function(Iris)
             end
         end)
 
-        Button.InputEnded:Connect(function(input)
+        Button.InputEnded:Connect(function(input: InputObject)
             if not (input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Gamepad1) or exitedButton then
                 return
             end
@@ -194,7 +196,7 @@ return function(Iris)
         Button.SelectionImageObject = Iris.SelectionImageObject
     end
 
-    function widgets.applyTextInteractionHighlights(Button, Highlightee, Colors)
+    function widgets.applyTextInteractionHighlights(Button: GuiButton, Highlightee: TextLabel | TextButton | TextBox, Colors: { [string]: any })
         local exitedButton = false
         Button.MouseEnter:Connect(function()
             Highlightee.TextColor3 = Colors.ButtonHoveredColor
@@ -210,7 +212,7 @@ return function(Iris)
             exitedButton = true
         end)
 
-        Button.InputBegan:Connect(function(input)
+        Button.InputBegan:Connect(function(input: InputObject)
             if not (input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Gamepad1) then
                 return
             end
@@ -218,7 +220,7 @@ return function(Iris)
             Highlightee.TextTransparency = Colors.ButtonActiveTransparency
         end)
 
-        Button.InputEnded:Connect(function(input)
+        Button.InputEnded:Connect(function(input: InputObject)
             if not (input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Gamepad1) or exitedButton then
                 return
             end
@@ -235,19 +237,19 @@ return function(Iris)
         Button.SelectionImageObject = Iris.SelectionImageObject
     end
 
-    function widgets.applyFrameStyle(thisInstance, forceNoPadding, doubleyNoPadding)
+    function widgets.applyFrameStyle(thisInstance: GuiObject, forceNoPadding: boolean?, doubleyNoPadding: boolean?)
         -- padding, border, and rounding
         -- optimized to only use what instances are needed, based on style
-        local FramePadding = Iris._config.FramePadding
-        local FrameBorderTransparency = Iris._config.ButtonTransparency
-        local FrameBorderSize = Iris._config.FrameBorderSize
-        local FrameBorderColor = Iris._config.BorderColor
-        local FrameRounding = Iris._config.FrameRounding
+        local FramePadding: Vector2 = Iris._config.FramePadding
+        local FrameBorderSize: number = Iris._config.FrameBorderSize
+        local FrameBorderColor: Color3 = Iris._config.BorderColor
+        local FrameBorderTransparency: number = Iris._config.ButtonTransparency
+        local FrameRounding: number = Iris._config.FrameRounding
         
         if FrameBorderSize > 0 and FrameRounding > 0 then
             thisInstance.BorderSizePixel = 0
 
-            local uiStroke = Instance.new("UIStroke")
+            local uiStroke: UIStroke = Instance.new("UIStroke")
             uiStroke.ApplyStrokeMode = Enum.ApplyStrokeMode.Border
             uiStroke.LineJoinMode = Enum.LineJoinMode.Round
             uiStroke.Transparency = FrameBorderTransparency
@@ -281,10 +283,10 @@ return function(Iris)
     end
 
     widgets.EVENTS = {
-        hover = function(pathToHovered)
+        hover = function(pathToHovered: (thisWidget: Types.Widget) -> GuiObject)
             return {
-                ["Init"] = function(thisWidget)
-                    local hoveredGuiObject = pathToHovered(thisWidget)
+                ["Init"] = function(thisWidget: Types.Widget)
+                    local hoveredGuiObject: GuiObject = pathToHovered(thisWidget)
                     hoveredGuiObject.MouseEnter:Connect(function()
                         thisWidget.isHoveredEvent = true
                     end)
@@ -293,55 +295,55 @@ return function(Iris)
                     end)
                     thisWidget.isHoveredEvent = false
                 end,
-                ["Get"] = function(thisWidget)
+                ["Get"] = function(thisWidget: Types.Widget): boolean
                     return thisWidget.isHoveredEvent
                 end
             }
         end,
 
-        click = function(pathToClicked)
+        click = function(pathToClicked: (thisWidget: Types.Widget) -> GuiButton)
             return {
-                ["Init"] = function(thisWidget)
-                    local clickedGuiObject = pathToClicked(thisWidget)
+                ["Init"] = function(thisWidget: Types.Widget)
+                    local clickedGuiObject: GuiButton = pathToClicked(thisWidget)
                     thisWidget.lastClickedTick = -1
 
                     clickedGuiObject.MouseButton1Click:Connect(function()
                         thisWidget.lastClickedTick = Iris._cycleTick + 1
                     end)
                 end,
-                ["Get"] = function(thisWidget)
+                ["Get"] = function(thisWidget: Types.Widget): boolean
                     return thisWidget.lastClickedTick == Iris._cycleTick
                 end
             }
         end,
 
-        rightClick = function(pathToClicked)
+        rightClick = function(pathToClicked: (thisWidget: Types.Widget) -> GuiButton)
             return {
-                ["Init"] = function(thisWidget)
-                    local clickedGuiObject = pathToClicked(thisWidget)
+                ["Init"] = function(thisWidget: Types.Widget)
+                    local clickedGuiObject: GuiButton = pathToClicked(thisWidget)
                     thisWidget.lastRightClickedTick = -1
 
                     clickedGuiObject.MouseButton2Click:Connect(function()
                         thisWidget.lastRightClickedTick = Iris._cycleTick + 1
                     end)
                 end,
-                ["Get"] = function(thisWidget)
+                ["Get"] = function(thisWidget: Types.Widget): boolean
                     return thisWidget.lastRightClickedTick == Iris._cycleTick
                 end
             }
         end,
 
-        doubleClick = function(pathToClicked)
+        doubleClick = function(pathToClicked: (thisWidget: Types.Widget) -> GuiButton)
             return {
-                ["Init"] = function(thisWidget)
-                    local clickedGuiObject = pathToClicked(thisWidget)
+                ["Init"] = function(thisWidget: Types.Widget)
+                    local clickedGuiObject: GuiButton = pathToClicked(thisWidget)
                     thisWidget.lastClickedTime = -1
                     thisWidget.lastClickedPosition = Vector2.zero
                     thisWidget.lastDoubleClickedTick = -1
 
-                    clickedGuiObject.MouseButton1Down:Connect(function(x, y)
-                        local currentTime = time()
-                        local isTimeValid = currentTime - thisWidget.lastClickedTime < Iris._config.MouseDoubleClickTime
+                    clickedGuiObject.MouseButton1Down:Connect(function(x: number, y: number)
+                        local currentTime: number = time()
+                        local isTimeValid: boolean = currentTime - thisWidget.lastClickedTime < Iris._config.MouseDoubleClickTime
                         if isTimeValid and (Vector2.new(x, y) - thisWidget.lastClickedPosition).Magnitude < Iris._config.MouseDoubleClickMaxDist then
                             thisWidget.lastDoubleClickedTick = Iris._cycleTick + 1
                         else
@@ -350,16 +352,16 @@ return function(Iris)
                         end
                     end)
                 end,
-                ["Get"] = function(thisWidget)
+                ["Get"] = function(thisWidget: Types.Widget): boolean
                     return thisWidget.lastDoubleClickedTick == Iris._cycleTick
                 end
             }
         end,
 
-        ctrlClick = function(pathToClicked)
+        ctrlClick = function(pathToClicked: (thisWidget: Types.Widget) -> GuiButton)
             return {
-                ["Init"] = function(thisWidget)
-                    local clickedGuiObject = pathToClicked(thisWidget)
+                ["Init"] = function(thisWidget: Types.Widget)
+                    local clickedGuiObject: GuiButton = pathToClicked(thisWidget)
                     thisWidget.lastCtrlClickedTick = -1
 
                     clickedGuiObject.MouseButton1Click:Connect(function()
@@ -368,15 +370,15 @@ return function(Iris)
                         end
                     end)
                 end,
-                ["Get"] = function(thisWidget)
+                ["Get"] = function(thisWidget: Types.Widget): boolean
                     return thisWidget.lastCtrlClickedTick == Iris._cycleTick
                 end
             }
         end
     }
 
-    function widgets.discardState(thisWidget)
-        for _, state in thisWidget.state do
+    function widgets.discardState(thisWidget: Types.Widget)
+        for _, state: Types.State in thisWidget.state do
             state.ConnectedWidgets[thisWidget.ID] = nil
         end
     end


### PR DESCRIPTION
## Additions
- Types have been added to the Iris.lua and widgets.lua files. Not all files have been updated to use full typing but they will be eventually. This is mainly a prefence to make it easier for creating new widgets. Not everything needs to be strictly typed so just typing functions may only be needed. I can go through and change this if needed.
- New SetNextWidgetID function to determine the id of the next widget.
- New continue widget mode which allows the same widget to be called multiple times. This works for calling the same window multiple times even after closing it.

## Tweaks
- Changed the font to use FontFace and the Font instance rather than Enums. This is not very difficult but when the style editor is updated the font selector will need to accommodate this.

### Notes
- The error which would happen if the same widget was called twice with the same ID has been removed. This is intended for widgets which have children such as windows, trees, collapsing headers, tables, etc. The update function is only called once and all it does is add the widget to the top of the stack. Ideally no one would try and call the same text widget twice, but I'm not sure what behaviour this would produce. Either we restrict which widgets can have multiple calls, or there is a safeguard to prevent unintended behaviour.
- Like Dear ImGui, window can be appended or 'continued' multiple times. However, since Iris uses Roblox's UI layouts, widgets like trees or collapsing headers which would not normally allow continuation in ImGui does work with Iris. This seems like a benefit and I can't see any glaring issues.