### PR TITLE
Nil check to prevent error on quick-swap with no windows

### DIFF
--- a/lib/widgets/Window.lua
+++ b/lib/widgets/Window.lua
@@ -115,6 +115,10 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             end
         end
 
+        if not lowestWidget then
+            return
+        end
+
         if lowestWidget.state.isUncollapsed.value == false then
             lowestWidget.state.isUncollapsed:set(true)
         end


### PR DESCRIPTION
Noticed that using quick swap (Ctrl + Tab or ButtonX) causes an error if no windows are currently active. Added a nil check to fix this.
![DpGzO9JjvA](https://github.com/Michael-48/Iris/assets/146721698/13c513d7-f178-49bf-883c-787d14661e9a)
