### PR TITLE
Allow Menus to showcase a KeyCode without a ModifierKey

### DIFF
--- a/lib/widgets/Menu.lua
+++ b/lib/widgets/Menu.lua
@@ -432,7 +432,11 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
 
             TextLabel.Text = thisWidget.arguments.Text
             if thisWidget.arguments.KeyCode then
-                Shortcut.Text = thisWidget.arguments.ModifierKey.Name .. " + " .. thisWidget.arguments.KeyCode.Name
+				if thisWidget.arguments.ModifierKey then
+					Shortcut.Text = thisWidget.arguments.ModifierKey.Name .. " + " .. thisWidget.arguments.KeyCode.Name
+				else
+					Shortcut.Text = thisWidget.arguments.KeyCode.Name
+				end
             end
         end,
         Discard = function(thisWidget: Types.Widget)
@@ -569,7 +573,11 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
 
             TextLabel.Text = thisWidget.arguments.Text
             if thisWidget.arguments.KeyCode then
-                Shortcut.Text = thisWidget.arguments.ModifierKey.Name .. " + " .. thisWidget.arguments.KeyCode.Name
+				if thisWidget.arguments.ModifierKey then
+					Shortcut.Text = thisWidget.arguments.ModifierKey.Name .. " + " .. thisWidget.arguments.KeyCode.Name
+				else
+					Shortcut.Text = thisWidget.arguments.KeyCode.Name
+				end
             end
         end,
         UpdateState = function(thisWidget: Types.Widget)


### PR DESCRIPTION
Current implementation requires Menus include ModifierKeys, otherwise it throws an error. This should be a user decision (Main cases are Delete / Backspace / any of the F1-F12).