### PR TITLE
Update ZIndex and LayoutOrder when late renders occur

### DIFF
--- a/lib/Internal.lua
+++ b/lib/Internal.lua
@@ -261,7 +261,7 @@ return function(Iris: Types.Iris): Types.Internal
         end
 
         if Internal._stackIndex ~= 1 then
-            -- has to be larger than 1 because of the check that it isint below 1 in Iris.End
+            -- has to be larger than 1 because of the check that it isnt below 1 in Iris.End
             Internal._stackIndex = 1
             error("Callback has too few calls to Iris.End()", 0)
         end
@@ -440,6 +440,14 @@ return function(Iris: Types.Iris): Types.Internal
         if thisWidget == nil then
             -- didnt find a match, generate a new widget.
             thisWidget = Internal._GenNewWidget(widgetType, arguments, states, ID)
+
+            -- all future widgets under the parent (except if the parent is the root) need to be regenerated
+            -- so that their layout is correct
+            -- see issue #58
+            local parentWidget = thisWidget.parentWidget
+            if parentWidget.ID ~= Internal._rootWidget.ID then
+                parentWidget.isDirty = true
+            end
         end
 
         if Internal._deepCompare(thisWidget.providedArguments, arguments) == false then
@@ -451,6 +459,14 @@ return function(Iris: Types.Iris): Types.Internal
             thisWidgetClass.Update(thisWidget)
         end
 
+        if thisWidget.parentWidget.isDirty then
+            -- since the parent was dirty, update the ZIndex of this component by regenerating it
+            -- so that items inserted in future cycles that are created before this component are correctly ordered before it
+            thisWidget.ZIndex = Internal._DiscardWidget(thisWidget)
+            thisWidget = Internal._GenNewWidget(widgetType, arguments, states, ID)
+            warn(`Regenerated {thisWidget.ID} with parent {thisWidget.parentWidget.ID} dirty. Instance {thisWidget.Instance:GetFullName()}`)
+        end
+
         thisWidget.lastCycleTick = Internal._cycleTick
         thisWidget.Disabled = Iris._config.DisableWidget
 
@@ -458,6 +474,9 @@ return function(Iris: Types.Iris): Types.Internal
             -- a parent widget, so we increase our depth.
             Internal._stackIndex += 1
             Internal._IDStack[Internal._stackIndex] = thisWidget.ID
+
+            -- if our parent is dirty, then we must be dirty so our children regenerate too
+            thisWidget.isDirty = thisWidget.parentWidget.isDirty
         end
 
         Internal._VDOM[ID] = thisWidget
@@ -492,6 +511,7 @@ return function(Iris: Types.Iris): Types.Internal
         thisWidget.type = widgetType
         thisWidget.parentWidget = Internal._VDOM[parentId]
         thisWidget.trackedEvents = {}
+        thisWidget.isDirty = false
 
         -- widgets have lots of space to ensure they are always visible.
         thisWidget.ZIndex = thisWidget.parentWidget.ZIndex + (Internal._widgetCount * 0x40) + Internal._config.ZIndexOffset

--- a/lib/Internal.lua
+++ b/lib/Internal.lua
@@ -460,11 +460,12 @@ return function(Iris: Types.Iris): Types.Internal
         end
 
         if thisWidget.parentWidget.isDirty then
-            -- since the parent was dirty, update the ZIndex of this component by regenerating it
+            -- since the parent was dirty, update the ZIndex of this component
             -- so that items inserted in future cycles that are created before this component are correctly ordered before it
-            thisWidget.ZIndex = Internal._DiscardWidget(thisWidget)
-            thisWidget = Internal._GenNewWidget(widgetType, arguments, states, ID)
-            warn(`Regenerated {thisWidget.ID} with parent {thisWidget.parentWidget.ID} dirty. Instance {thisWidget.Instance:GetFullName()}`)
+            thisWidget.ZIndex = thisWidget.parentWidget.ZIndex + (Internal._widgetCount * 0x40) + Internal._config.ZIndexOffset
+
+            thisWidget.Instance.ZIndex = thisWidget.ZIndex
+            thisWidget.Instance.LayoutOrder = thisWidget.ZIndex
         end
 
         thisWidget.lastCycleTick = Internal._cycleTick

--- a/lib/Types.lua
+++ b/lib/Types.lua
@@ -113,6 +113,7 @@ export type Widget = {
     state: States,
     lastCycleTick: number,
     trackedEvents: {},
+    isDirty: boolean,
 
     parentWidget: Widget,
     Instance: GuiObject,
@@ -220,8 +221,8 @@ export type WidgetUtility = {
     },
 
     GuiInset: Vector2?,
-    setGuiInset: () -> (Vector2),
-    getGuiInset: () -> (Vector2),
+    setGuiInset: () -> Vector2,
+    getGuiInset: () -> Vector2,
 
     findBestWindowPosForPopup: (refPos: Vector2, size: Vector2, outerMin: Vector2, outerMax: Vector2) -> Vector2,
     getScreenSizeForWindow: (thisWidget: Widget) -> Vector2,

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -203,6 +203,13 @@ function Iris.End()
     if Internal._stackIndex == 1 then
         error("Callback has too many calls to Iris.End()", 2)
     end
+
+    -- Mark the parent widget as no longer dirty
+    local parent = Internal._GetParentWidget()
+    if parent.isDirty then
+        parent.isDirty = false
+    end
+
     Internal._IDStack[Internal._stackIndex] = nil
     Internal._stackIndex -= 1
 end


### PR DESCRIPTION
Currently, Iris does not well support components which conditionally render, or render later (see #58 and #48).

This patch marks parents as dirty when a new component is rendered, which triggers an update of the computed ZIndex and LayoutOrder for those future children of the parent. This correctly orders elements, albeit with a ~1 cycle delay in the order looking correct (minor flickering).

This patch is not completely ideal -- as we naively assume that setting the LayoutOrder and ZIndex of the widget's root Instance is sufficient. This assumption breaks down as Iris uses ZIndexBehavior=Global, and so we need to propagate an update of ZIndex/LayoutOrder to all instances generated by a widget -- not just the root widget.

For simple cases however, this patch is suitable.