### PR TITLE
Change Widget Layout Order

### DIFF
--- a/lib/Internal.lua
+++ b/lib/Internal.lua
@@ -26,7 +26,6 @@ return function(Iris: Types.Iris): Types.Internal
 
     -- Widgets & Instances
     Internal._widgets = {}
-    Internal._widgetCount = 0 -- only used to compute ZIndex, resets to 0 for every cycle
     Internal._stackIndex = 1 -- Points to the index that IDStack is currently in, when computing cycle
     Internal._rootInstance = nil
     Internal._rootWidget = {
@@ -34,6 +33,7 @@ return function(Iris: Types.Iris): Types.Internal
         type = "Root",
         Instance = Internal._rootInstance,
         ZIndex = 0,
+        ZOffset = 0,
     }
     Internal._lastWidget = Internal._rootWidget -- widget which was most recently rendered
 
@@ -224,7 +224,6 @@ return function(Iris: Types.Iris): Types.Internal
 
         -- update counters
         Internal._cycleTick += 1
-        Internal._widgetCount = 0
         table.clear(Internal._usedIDs)
 
         -- if Internal.parentInstance:IsA("GuiBase2d") and math.min(Internal.parentInstance.AbsoluteSize.X, Internal.parentInstance.AbsoluteSize.Y) < 100 then
@@ -411,7 +410,6 @@ return function(Iris: Types.Iris): Types.Internal
 
         -- fetch the widget class which contains all the functions for the widget.
         local thisWidgetClass: Types.WidgetClass = Internal._widgets[widgetType]
-        Internal._widgetCount += 1
 
         if Internal._VDOM[ID] then
             -- widget already created once this frame, so we can append to it.
@@ -444,13 +442,20 @@ return function(Iris: Types.Iris): Types.Internal
         if thisWidget == nil then
             -- didnt find a match, generate a new widget.
             thisWidget = Internal._GenNewWidget(widgetType, arguments, states, ID)
+        end
+        local parentWidget: Types.Widget = thisWidget.parentWidget
 
-            -- all future widgets under the parent (except if the parent is the root) need to be regenerated
-            -- so that their layout is correct
-            -- see issue #58
-            local parentWidget = thisWidget.parentWidget
-            if parentWidget.ID ~= Internal._rootWidget.ID then
-                parentWidget.isDirty = true
+        if thisWidget.type ~= "Window" and thisWidget.type ~= "Tooltip" then
+            if thisWidget.ZIndex ~= parentWidget.ZOffset then
+                parentWidget.ZUpdate = true
+            end
+
+            if parentWidget.ZUpdate then
+                thisWidget.ZIndex = parentWidget.ZOffset
+                if thisWidget.Instance then
+                    thisWidget.Instance.ZIndex = thisWidget.ZIndex
+                    thisWidget.Instance.LayoutOrder = thisWidget.ZIndex
+                end
             end
         end
 
@@ -463,25 +468,15 @@ return function(Iris: Types.Iris): Types.Internal
             thisWidgetClass.Update(thisWidget)
         end
 
-        if thisWidget.parentWidget.isDirty then
-            -- since the parent was dirty, update the ZIndex of this component
-            -- so that items inserted in future cycles that are created before this component are correctly ordered before it
-            thisWidget.ZIndex = thisWidget.parentWidget.ZIndex + (Internal._widgetCount * 0x40) + Internal._config.ZIndexOffset
-
-            thisWidget.Instance.ZIndex = thisWidget.ZIndex
-            thisWidget.Instance.LayoutOrder = thisWidget.ZIndex
-        end
-
         thisWidget.lastCycleTick = Internal._cycleTick
-        thisWidget.Disabled = Iris._config.DisableWidget
+        parentWidget.ZOffset += 1
 
         if thisWidgetClass.hasChildren then
             -- a parent widget, so we increase our depth.
+            thisWidget.ZOffset = 0
+            thisWidget.ZUpdate = false
             Internal._stackIndex += 1
             Internal._IDStack[Internal._stackIndex] = thisWidget.ID
-
-            -- if our parent is dirty, then we must be dirty so our children regenerate too
-            thisWidget.isDirty = thisWidget.parentWidget.isDirty
         end
 
         Internal._VDOM[ID] = thisWidget
@@ -506,6 +501,7 @@ return function(Iris: Types.Iris): Types.Internal
     ]=]
     function Internal._GenNewWidget(widgetType: string, arguments: Types.Arguments, states: Types.WidgetStates?, ID: Types.ID): Types.Widget
         local parentId: Types.ID = Internal._IDStack[Internal._stackIndex]
+        local parentWidget: Types.Widget = Internal._VDOM[parentId]
         local thisWidgetClass: Types.WidgetClass = Internal._widgets[widgetType]
 
         -- widgets are just tables with properties.
@@ -514,15 +510,21 @@ return function(Iris: Types.Iris): Types.Internal
 
         thisWidget.ID = ID
         thisWidget.type = widgetType
-        thisWidget.parentWidget = Internal._VDOM[parentId]
+        thisWidget.parentWidget = parentWidget
         thisWidget.trackedEvents = {}
-        thisWidget.isDirty = false
 
         -- widgets have lots of space to ensure they are always visible.
-        thisWidget.ZIndex = thisWidget.parentWidget.ZIndex + (Internal._widgetCount * 0x40) + Internal._config.ZIndexOffset
+        thisWidget.ZIndex = parentWidget.ZOffset
 
         thisWidget.Instance = thisWidgetClass.Generate(thisWidget)
-        thisWidget.Instance.Parent = if Internal._config.Parent then Internal._config.Parent else Internal._widgets[thisWidget.parentWidget.type].ChildAdded(thisWidget.parentWidget, thisWidget)
+        -- tooltips set their parent in the generation method, so we need to udpate it here
+        parentWidget = thisWidget.parentWidget
+
+        if Internal._config.Parent then
+            thisWidget.Instance.Parent = Internal._config.Parent
+        else
+            thisWidget.Instance.Parent = Internal._widgets[parentWidget.type].ChildAdded(parentWidget, thisWidget)
+        end
 
         -- we can modify the arguments table, but keep a frozen copy to compare for user-end changes.
         thisWidget.providedArguments = arguments

--- a/lib/Types.lua
+++ b/lib/Types.lua
@@ -1,5 +1,10 @@
 export type ID = string
 
+-- Arguments, States & Events
+
+export type InputDataType = number | Vector2 | Vector3 | UDim | UDim2 | Color3 | Rect | { number }
+export type InputDataTypes = "Num" | "Vector2" | "Vector3" | "UDim" | "UDim2" | "Color3" | "Color4" | "Rect" | "Enum" | "" | string
+
 export type Argument = any
 export type Arguments = {
     [string]: Argument,
@@ -91,10 +96,7 @@ export type Event = {
 }
 export type Events = { [string]: Event }
 
-type EventAPI = () -> boolean
-
-export type InputDataType = number | Vector2 | Vector3 | UDim | UDim2 | Color3 | Rect | { number }
-export type InputDataTypes = "Num" | "Vector2" | "Vector3" | "UDim" | "UDim2" | "Color3" | "Color4" | "Rect" | "Enum" | "" | string
+-- Widgets
 
 export type WidgetArguments = { [number]: Argument }
 export type WidgetStates = {
@@ -115,27 +117,32 @@ export type WidgetStates = {
     [string]: State,
 }
 
+type EventAPI = () -> boolean
 export type Widget = {
     ID: ID,
     type: string,
-    state: States,
     lastCycleTick: number,
     trackedEvents: {},
-    isDirty: boolean,
-
     parentWidget: Widget,
-    Instance: GuiObject,
-    ChildContainer: GuiObject,
-    Disabled: boolean,
+
+    state: States,
     arguments: Arguments,
     providedArguments: Arguments,
+
+    Instance: GuiObject,
     ZIndex: number,
 
+    -- Parents
+    ChildContainer: GuiObject,
+    ZOffset: number,
+    ZUpdate: boolean,
+
     usesScreenGUI: boolean,
+
+    -- Combo & Table properties
     ButtonColors: { [string]: Color3 | number },
     ComboChildrenHeight: number,
 
-    -- Table properties
     RowColumnIndex: number,
     InitialNumColumns: number,
     ColumnInstances: { Frame },
@@ -209,166 +216,7 @@ export type WidgetClass = {
     ChildDiscarded: (thisWidget: Widget, thisChild: Widget) -> (),
 }
 
-export type WidgetUtility = {
-    GuiService: GuiService,
-    RunService: RunService,
-    TextService: TextService,
-    UserInputService: UserInputService,
-    ContextActionService: ContextActionService,
-
-    getTime: () -> number,
-    getMouseLocation: () -> Vector2,
-
-    ICONS: {
-        RIGHT_POINTING_TRIANGLE: string,
-        DOWN_POINTING_TRIANGLE: string,
-        MULTIPLICATION_SIGN: string,
-        BOTTOM_RIGHT_CORNER: string,
-        CHECK_MARK: string,
-        ALPHA_BACKGROUND_TEXTURE: string,
-        UNKNOWN_TEXTURE: string,
-    },
-
-    GuiInset: Vector2?,
-    setGuiInset: () -> Vector2,
-    getGuiInset: () -> Vector2,
-
-    findBestWindowPosForPopup: (refPos: Vector2, size: Vector2, outerMin: Vector2, outerMax: Vector2) -> Vector2,
-    getScreenSizeForWindow: (thisWidget: Widget) -> Vector2,
-    isPosInsideRect: (pos: Vector2, rectMin: Vector2, rectMax: Vector2) -> boolean,
-    extend: (superClass: WidgetClass, { [any]: any }) -> WidgetClass,
-    discardState: (thisWidget: Widget) -> (),
-
-    UIPadding: (Parent: GuiObject, PxPadding: Vector2) -> UIPadding,
-    UIListLayout: (Parent: GuiObject, FillDirection: Enum.FillDirection, Padding: UDim) -> UIListLayout,
-    UIStroke: (Parent: GuiObject, Thickness: number, Color: Color3, Transparency: number) -> UIStroke,
-    UICorner: (Parent: GuiObject, PxRounding: number?) -> UICorner,
-    UISizeConstraint: (Parent: GuiObject, MinSize: Vector2?, MaxSize: Vector2?) -> UISizeConstraint,
-    UIReference: (Parent: GuiObject, Child: GuiObject, Name: string) -> ObjectValue,
-
-    calculateTextSize: (text: string, width: number?) -> Vector2,
-    applyTextStyle: (thisInstance: TextLabel | TextButton | TextBox) -> (),
-    applyInteractionHighlights: (thisWidget: Widget, Button: GuiButton, Highlightee: GuiObject, Colors: { [string]: any }) -> (),
-    applyInteractionHighlightsWithMultiHighlightee: (thisWidget: Widget, Button: GuiButton, Highlightees: { { GuiObject | { [string]: Color3 | number } } }) -> (),
-    applyImageInteractionHighlights: (thisWidget: Widget, Button: GuiButton, Highlightee: GuiObject, Colors: { [string]: any }) -> (),
-    applyTextInteractionHighlights: (thisWidget: Widget, Button: GuiButton, Highlightee: TextLabel | TextButton | TextBox, Colors: { [string]: any }) -> (),
-    applyFrameStyle: (thisInstance: GuiObject, noPadding: boolean?, noCorner: boolean?) -> (),
-
-    applyButtonClick: (thisWidget: Widget, thisInstance: GuiButton, callback: () -> ()) -> (),
-    applyButtonDown: (thisWidget: Widget, thisInstance: GuiButton, callback: (x: number, y: number) -> ()) -> (),
-    applyMouseEnter: (thisWidget: Widget, thisInstance: GuiObject, callback: () -> ()) -> (),
-    applyMouseLeave: (thisWidget: Widget, thisInstance: GuiObject, callback: () -> ()) -> (),
-    applyInputBegan: (thisWidget: Widget, thisInstance: GuiObject, callback: (input: InputObject) -> ()) -> (),
-    applyInputEnded: (thisWidget: Widget, thisInstance: GuiObject, callback: (input: InputObject) -> ()) -> (),
-
-    registerEvent: (event: string, callback: (...any) -> ()) -> (),
-
-    EVENTS: {
-        hover: (pathToHovered: (thisWidget: Widget) -> GuiObject) -> Event,
-        click: (pathToClicked: (thisWidget: Widget) -> GuiButton) -> Event,
-        rightClick: (pathToClicked: (thisWidget: Widget) -> GuiButton) -> Event,
-        doubleClick: (pathToClicked: (thisWidget: Widget) -> GuiButton) -> Event,
-        ctrlClick: (pathToClicked: (thisWidget: Widget) -> GuiButton) -> Event,
-    },
-
-    abstractButton: WidgetClass,
-}
-
-export type Internal = {
-    --[[
-        --------------
-          PROPERTIES
-        --------------
-    ]]
-    _version: string,
-    _started: boolean,
-    _shutdown: boolean,
-    _cycleTick: number,
-    _eventConnection: RBXScriptConnection?,
-
-    -- Refresh
-    _globalRefreshRequested: boolean,
-    _localRefreshActive: boolean,
-
-    -- Widgets & Instances
-    _widgets: { [string]: WidgetClass },
-    _widgetCount: number,
-    _stackIndex: number,
-    _rootInstance: GuiObject?,
-    _rootWidget: Widget,
-    _lastWidget: Widget,
-    SelectionImageObject: Frame,
-    parentInstance: BasePlayerGui,
-    _utility: WidgetUtility,
-
-    -- Config
-    _rootConfig: Config,
-    _config: Config,
-
-    -- ID
-    _IDStack: { ID },
-    _usedIDs: { [ID]: number },
-    _pushedId: ID?,
-    _nextWidgetId: ID?,
-
-    -- VDOM
-    _lastVDOM: { [ID]: Widget },
-    _VDOM: { [ID]: Widget },
-
-    -- State
-    _states: { [ID]: State },
-
-    -- Callback
-    _postCycleCallbacks: { () -> () },
-    _connectedFunctions: { () -> () },
-    _connections: { RBXScriptConnection },
-    _initFunctions: { () -> () },
-    _cycleCoroutine: thread?,
-
-    --[[
-        ---------
-          STATE
-        ---------
-    ]]
-
-    StateClass: {
-        __index: any,
-
-        get: (self: State) -> any,
-        set: (self: State, newValue: any) -> any,
-        onChange: (self: State, callback: (newValue: any) -> ()) -> (),
-    },
-
-    --[[
-        -------------
-          FUNCTIONS
-        -------------
-    ]]
-    _cycle: () -> (),
-    _NoOp: () -> (),
-
-    -- Widget
-    WidgetConstructor: (type: string, widgetClass: WidgetClass) -> (),
-    _Insert: (widgetType: string, arguments: WidgetArguments?, states: WidgetStates?) -> Widget,
-    _GenNewWidget: (widgetType: string, arguments: Arguments, states: WidgetStates?, ID: ID) -> Widget,
-    _ContinueWidget: (ID: ID, widgetType: string) -> Widget,
-    _DiscardWidget: (widgetToDiscard: Widget) -> (),
-
-    _widgetState: (thisWidget: Widget, stateName: string, initialValue: any) -> State,
-    _EventCall: (thisWidget: Widget, eventName: string) -> boolean,
-    _GetParentWidget: () -> Widget,
-    SetFocusedWindow: (thisWidget: Widget?) -> (),
-
-    -- Generate
-    _generateEmptyVDOM: () -> { [ID]: Widget },
-    _generateRootInstance: () -> (),
-    _generateSelectionImageObject: () -> (),
-
-    -- Utility
-    _getID: (levelsToIgnore: number) -> ID,
-    _deepCompare: (t1: {}, t2: {}) -> boolean,
-    _deepCopy: (t: {}) -> {},
-}
+-- Iris
 
 export type Iris = {
     --[[
@@ -506,6 +354,166 @@ export type Iris = {
     TemplateConfig: { [string]: Config },
     _config: Config,
     ShowDemoWindow: () -> Widget,
+}
+
+export type Internal = {
+    --[[
+        --------------
+          PROPERTIES
+        --------------
+    ]]
+    _version: string,
+    _started: boolean,
+    _shutdown: boolean,
+    _cycleTick: number,
+    _eventConnection: RBXScriptConnection?,
+
+    -- Refresh
+    _globalRefreshRequested: boolean,
+    _localRefreshActive: boolean,
+
+    -- Widgets & Instances
+    _widgets: { [string]: WidgetClass },
+    _stackIndex: number,
+    _rootInstance: GuiObject?,
+    _rootWidget: Widget,
+    _lastWidget: Widget,
+    SelectionImageObject: Frame,
+    parentInstance: BasePlayerGui,
+    _utility: WidgetUtility,
+
+    -- Config
+    _rootConfig: Config,
+    _config: Config,
+
+    -- ID
+    _IDStack: { ID },
+    _usedIDs: { [ID]: number },
+    _pushedId: ID?,
+    _nextWidgetId: ID?,
+
+    -- VDOM
+    _lastVDOM: { [ID]: Widget },
+    _VDOM: { [ID]: Widget },
+
+    -- State
+    _states: { [ID]: State },
+
+    -- Callback
+    _postCycleCallbacks: { () -> () },
+    _connectedFunctions: { () -> () },
+    _connections: { RBXScriptConnection },
+    _initFunctions: { () -> () },
+    _cycleCoroutine: thread?,
+
+    --[[
+        ---------
+          STATE
+        ---------
+    ]]
+
+    StateClass: {
+        __index: any,
+
+        get: (self: State) -> any,
+        set: (self: State, newValue: any) -> any,
+        onChange: (self: State, callback: (newValue: any) -> ()) -> (),
+    },
+
+    --[[
+        -------------
+          FUNCTIONS
+        -------------
+    ]]
+    _cycle: () -> (),
+    _NoOp: () -> (),
+
+    -- Widget
+    WidgetConstructor: (type: string, widgetClass: WidgetClass) -> (),
+    _Insert: (widgetType: string, arguments: WidgetArguments?, states: WidgetStates?) -> Widget,
+    _GenNewWidget: (widgetType: string, arguments: Arguments, states: WidgetStates?, ID: ID) -> Widget,
+    _ContinueWidget: (ID: ID, widgetType: string) -> Widget,
+    _DiscardWidget: (widgetToDiscard: Widget) -> (),
+
+    _widgetState: (thisWidget: Widget, stateName: string, initialValue: any) -> State,
+    _EventCall: (thisWidget: Widget, eventName: string) -> boolean,
+    _GetParentWidget: () -> Widget,
+    SetFocusedWindow: (thisWidget: Widget?) -> (),
+
+    -- Generate
+    _generateEmptyVDOM: () -> { [ID]: Widget },
+    _generateRootInstance: () -> (),
+    _generateSelectionImageObject: () -> (),
+
+    -- Utility
+    _getID: (levelsToIgnore: number) -> ID,
+    _deepCompare: (t1: {}, t2: {}) -> boolean,
+    _deepCopy: (t: {}) -> {},
+}
+
+export type WidgetUtility = {
+    GuiService: GuiService,
+    RunService: RunService,
+    TextService: TextService,
+    UserInputService: UserInputService,
+    ContextActionService: ContextActionService,
+
+    getTime: () -> number,
+    getMouseLocation: () -> Vector2,
+
+    ICONS: {
+        RIGHT_POINTING_TRIANGLE: string,
+        DOWN_POINTING_TRIANGLE: string,
+        MULTIPLICATION_SIGN: string,
+        BOTTOM_RIGHT_CORNER: string,
+        CHECK_MARK: string,
+        ALPHA_BACKGROUND_TEXTURE: string,
+        UNKNOWN_TEXTURE: string,
+    },
+
+    GuiInset: Vector2?,
+    setGuiInset: () -> Vector2,
+    getGuiInset: () -> Vector2,
+
+    findBestWindowPosForPopup: (refPos: Vector2, size: Vector2, outerMin: Vector2, outerMax: Vector2) -> Vector2,
+    getScreenSizeForWindow: (thisWidget: Widget) -> Vector2,
+    isPosInsideRect: (pos: Vector2, rectMin: Vector2, rectMax: Vector2) -> boolean,
+    extend: (superClass: WidgetClass, { [any]: any }) -> WidgetClass,
+    discardState: (thisWidget: Widget) -> (),
+
+    UIPadding: (Parent: GuiObject, PxPadding: Vector2) -> UIPadding,
+    UIListLayout: (Parent: GuiObject, FillDirection: Enum.FillDirection, Padding: UDim) -> UIListLayout,
+    UIStroke: (Parent: GuiObject, Thickness: number, Color: Color3, Transparency: number) -> UIStroke,
+    UICorner: (Parent: GuiObject, PxRounding: number?) -> UICorner,
+    UISizeConstraint: (Parent: GuiObject, MinSize: Vector2?, MaxSize: Vector2?) -> UISizeConstraint,
+    UIReference: (Parent: GuiObject, Child: GuiObject, Name: string) -> ObjectValue,
+
+    calculateTextSize: (text: string, width: number?) -> Vector2,
+    applyTextStyle: (thisInstance: TextLabel | TextButton | TextBox) -> (),
+    applyInteractionHighlights: (thisWidget: Widget, Button: GuiButton, Highlightee: GuiObject, Colors: { [string]: any }) -> (),
+    applyInteractionHighlightsWithMultiHighlightee: (thisWidget: Widget, Button: GuiButton, Highlightees: { { GuiObject | { [string]: Color3 | number } } }) -> (),
+    applyImageInteractionHighlights: (thisWidget: Widget, Button: GuiButton, Highlightee: GuiObject, Colors: { [string]: any }) -> (),
+    applyTextInteractionHighlights: (thisWidget: Widget, Button: GuiButton, Highlightee: TextLabel | TextButton | TextBox, Colors: { [string]: any }) -> (),
+    applyFrameStyle: (thisInstance: GuiObject, noPadding: boolean?, noCorner: boolean?) -> (),
+
+    applyButtonClick: (thisWidget: Widget, thisInstance: GuiButton, callback: () -> ()) -> (),
+    applyButtonDown: (thisWidget: Widget, thisInstance: GuiButton, callback: (x: number, y: number) -> ()) -> (),
+    applyMouseEnter: (thisWidget: Widget, thisInstance: GuiObject, callback: () -> ()) -> (),
+    applyMouseLeave: (thisWidget: Widget, thisInstance: GuiObject, callback: () -> ()) -> (),
+    applyInputBegan: (thisWidget: Widget, thisInstance: GuiObject, callback: (input: InputObject) -> ()) -> (),
+    applyInputEnded: (thisWidget: Widget, thisInstance: GuiObject, callback: (input: InputObject) -> ()) -> (),
+
+    registerEvent: (event: string, callback: (...any) -> ()) -> (),
+
+    EVENTS: {
+        hover: (pathToHovered: (thisWidget: Widget) -> GuiObject) -> Event,
+        click: (pathToClicked: (thisWidget: Widget) -> GuiButton) -> Event,
+        rightClick: (pathToClicked: (thisWidget: Widget) -> GuiButton) -> Event,
+        doubleClick: (pathToClicked: (thisWidget: Widget) -> GuiButton) -> Event,
+        ctrlClick: (pathToClicked: (thisWidget: Widget) -> GuiButton) -> Event,
+    },
+
+    abstractButton: WidgetClass,
 }
 
 export type Config = {

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -208,12 +208,6 @@ function Iris.End()
         error("Callback has too many calls to Iris.End()", 2)
     end
 
-    -- Mark the parent widget as no longer dirty
-    local parent = Internal._GetParentWidget()
-    if parent.isDirty then
-        parent.isDirty = false
-    end
-
     Internal._IDStack[Internal._stackIndex] = nil
     Internal._stackIndex -= 1
 end

--- a/lib/widgets/Checkbox.lua
+++ b/lib/widgets/Checkbox.lua
@@ -33,9 +33,8 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             Checkbox.Size = UDim2.fromOffset(0, 0)
             Checkbox.Text = ""
             Checkbox.AutomaticSize = Enum.AutomaticSize.XY
-            Checkbox.ZIndex = thisWidget.ZIndex
-            Checkbox.AutoButtonColor = false
             Checkbox.LayoutOrder = thisWidget.ZIndex
+            Checkbox.AutoButtonColor = false
 
             local checkboxSize: number = Iris._config.TextSize + 2 * Iris._config.FramePadding.Y
 
@@ -44,8 +43,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             CheckboxBox.Size = UDim2.fromOffset(checkboxSize, checkboxSize)
             CheckboxBox.BackgroundColor3 = Iris._config.FrameBgColor
             CheckboxBox.BackgroundTransparency = Iris._config.FrameBgTransparency
-            CheckboxBox.ZIndex = thisWidget.ZIndex + 1
-            CheckboxBox.LayoutOrder = thisWidget.ZIndex + 1
             widgets.applyFrameStyle(CheckboxBox, true)
 
             widgets.applyInteractionHighlights(thisWidget, Checkbox, CheckboxBox, {
@@ -70,8 +67,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             Checkmark.ImageColor3 = Iris._config.CheckMarkColor
             Checkmark.ImageTransparency = Iris._config.CheckMarkTransparency
             Checkmark.ScaleType = Enum.ScaleType.Fit
-            Checkmark.ZIndex = thisWidget.ZIndex + 2
-            Checkmark.LayoutOrder = thisWidget.ZIndex + 2
+            Checkmark.ZIndex = 2
 
             Checkmark.Parent = Checkbox
 
@@ -85,8 +81,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             widgets.applyTextStyle(TextLabel)
             TextLabel.AnchorPoint = Vector2.new(0, 0.5)
             TextLabel.Position = UDim2.new(0, checkboxSize + Iris._config.ItemInnerSpacing.X, 0.5, 0)
-            TextLabel.ZIndex = thisWidget.ZIndex + 1
-            TextLabel.LayoutOrder = thisWidget.ZIndex + 1
             TextLabel.AutomaticSize = Enum.AutomaticSize.XY
             TextLabel.BackgroundTransparency = 1
             TextLabel.BorderSizePixel = 0

--- a/lib/widgets/Combo.lua
+++ b/lib/widgets/Combo.lua
@@ -221,7 +221,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             Combo.AutomaticSize = Enum.AutomaticSize.Y
             Combo.BackgroundTransparency = 1
             Combo.BorderSizePixel = 0
-            Combo.ZIndex = thisWidget.ZIndex
             Combo.LayoutOrder = thisWidget.ZIndex
 
             widgets.UIListLayout(Combo, Enum.FillDirection.Horizontal, UDim.new(0, Iris._config.ItemInnerSpacing.Y + 1))
@@ -233,7 +232,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             PreviewContainer.BackgroundTransparency = 1
             PreviewContainer.Text = ""
             PreviewContainer.ZIndex = thisWidget.ZIndex + 2
-            PreviewContainer.LayoutOrder = thisWidget.ZIndex + 2
             PreviewContainer.AutoButtonColor = false
 
             widgets.applyFrameStyle(PreviewContainer, true)
@@ -248,8 +246,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             PreviewLabel.BackgroundColor3 = Iris._config.FrameBgColor
             PreviewLabel.BackgroundTransparency = Iris._config.FrameBgTransparency
             PreviewLabel.BorderSizePixel = 0
-            PreviewLabel.ZIndex = thisWidget.ZIndex + 3
-            PreviewLabel.LayoutOrder = thisWidget.ZIndex + 3
             PreviewLabel.ClipsDescendants = true
 
             widgets.applyTextStyle(PreviewLabel)
@@ -264,8 +260,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             DropdownButton.BackgroundColor3 = Iris._config.ButtonColor
             DropdownButton.BackgroundTransparency = Iris._config.ButtonTransparency
             DropdownButton.Text = ""
-            DropdownButton.ZIndex = thisWidget.ZIndex + 4
-            DropdownButton.LayoutOrder = thisWidget.ZIndex + 4
 
             local padding: number = math.round(frameHeight * 0.2)
             local dropdownSize: number = frameHeight - 2 * padding
@@ -278,10 +272,9 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             Dropdown.BorderSizePixel = 0
             Dropdown.ImageColor3 = Iris._config.TextColor
             Dropdown.ImageTransparency = Iris._config.TextTransparency
-            Dropdown.ZIndex = thisWidget.ZIndex + 5
-            Dropdown.LayoutOrder = thisWidget.ZIndex + 5
 
             Dropdown.Parent = DropdownButton
+
             DropdownButton.Parent = PreviewContainer
 
             -- for some reason ImGui Combo has no highlights for Active, only hovered.
@@ -327,8 +320,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             TextLabel.AutomaticSize = Enum.AutomaticSize.X
             TextLabel.BackgroundTransparency = 1
             TextLabel.BorderSizePixel = 0
-            TextLabel.ZIndex = thisWidget.ZIndex + 5
-            TextLabel.LayoutOrder = thisWidget.ZIndex + 5
 
             widgets.applyTextStyle(TextLabel)
 
@@ -348,8 +339,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             ChildContainer.VerticalScrollBarInset = Enum.ScrollBarInset.ScrollBar
 
             -- appear over everything else
-            ChildContainer.ZIndex = thisWidget.ZIndex + 6
-            ChildContainer.LayoutOrder = thisWidget.ZIndex + 6
             ChildContainer.ClipsDescendants = true
 
             -- Unfortunatley, ScrollingFrame does not work with UICorner

--- a/lib/widgets/Format.lua
+++ b/lib/widgets/Format.lua
@@ -18,7 +18,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             else
                 Separator.Size = UDim2.new(1, 0, 0, 1)
             end
-            Separator.ZIndex = thisWidget.ZIndex
             Separator.LayoutOrder = thisWidget.ZIndex
 
             widgets.UIListLayout(Separator, Enum.FillDirection.Vertical, UDim.new(0, 0))
@@ -47,7 +46,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             Indent.BorderSizePixel = 0
             Indent.Size = UDim2.fromScale(1, 0)
             Indent.AutomaticSize = Enum.AutomaticSize.Y
-            Indent.ZIndex = thisWidget.ZIndex
             Indent.LayoutOrder = thisWidget.ZIndex
 
             widgets.UIListLayout(Indent, Enum.FillDirection.Vertical, UDim.new(0, Iris._config.ItemSpacing.Y))
@@ -90,7 +88,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             SameLine.BorderSizePixel = 0
             SameLine.Size = UDim2.fromScale(1, 0)
             SameLine.AutomaticSize = Enum.AutomaticSize.Y
-            SameLine.ZIndex = thisWidget.ZIndex
             SameLine.LayoutOrder = thisWidget.ZIndex
 
             widgets.UIListLayout(SameLine, Enum.FillDirection.Horizontal, UDim.new(0, 0))
@@ -130,11 +127,10 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
         Generate = function(thisWidget: Types.Widget): Frame
             local Group: Frame = Instance.new("Frame")
             Group.Name = "Iris_Group"
+            Group.AutomaticSize = Enum.AutomaticSize.XY
+            Group.Size = UDim2.fromOffset(0, 0)
             Group.BackgroundTransparency = 1
             Group.BorderSizePixel = 0
-            Group.Size = UDim2.fromOffset(0, 0)
-            Group.AutomaticSize = Enum.AutomaticSize.XY
-            Group.ZIndex = thisWidget.ZIndex
             Group.LayoutOrder = thisWidget.ZIndex
             Group.ClipsDescendants = false
 

--- a/lib/widgets/Image.lua
+++ b/lib/widgets/Image.lua
@@ -33,7 +33,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 Image.BorderSizePixel = 0
                 Image.ImageColor3 = Iris._config.ImageColor
                 Image.ImageTransparency = Iris._config.ImageTransparency
-                Image.ZIndex = thisWidget.ZIndex
                 Image.LayoutOrder = thisWidget.ZIndex
 
                 widgets.applyFrameStyle(Image, true)
@@ -99,7 +98,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 Button.BorderSizePixel = 0
                 Button.Image = ""
                 Button.ImageTransparency = 1
-                Button.ZIndex = thisWidget.ZIndex
                 Button.LayoutOrder = thisWidget.ZIndex
                 Button.AutoButtonColor = false
                 
@@ -112,8 +110,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 Image.BorderSizePixel = 0
                 Image.ImageColor3 = Iris._config.ImageColor
                 Image.ImageTransparency = Iris._config.ImageTransparency
-                Image.ZIndex = thisWidget.ZIndex
-                Image.LayoutOrder = thisWidget.ZIndex
                 Image.Parent = Button
 
                 widgets.applyInteractionHighlights(thisWidget, Button, Button, {

--- a/lib/widgets/Input.lua
+++ b/lib/widgets/Input.lua
@@ -266,7 +266,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                     Input.Size = UDim2.fromScale(1, 0)
                     Input.BackgroundTransparency = 1
                     Input.BorderSizePixel = 0
-                    Input.ZIndex = thisWidget.ZIndex
                     Input.LayoutOrder = thisWidget.ZIndex
                     Input.AutomaticSize = Enum.AutomaticSize.Y
                     widgets.UIListLayout(Input, Enum.FillDirection.Horizontal, UDim.new(0, Iris._config.ItemInnerSpacing.X))
@@ -290,8 +289,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                     for index = 1, components do
                         local InputField: TextBox = Instance.new("TextBox")
                         InputField.Name = "InputField" .. tostring(index)
-                        InputField.ZIndex = thisWidget.ZIndex + index
-                        InputField.LayoutOrder = thisWidget.ZIndex + index
+                        InputField.LayoutOrder = index
                         if index == components then
                             InputField.Size = UDim2.new(lastComponentWidth, UDim.new())
                         else
@@ -350,8 +348,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                     TextLabel.Size = UDim2.fromOffset(0, textHeight)
                     TextLabel.BackgroundTransparency = 1
                     TextLabel.BorderSizePixel = 0
-                    TextLabel.ZIndex = thisWidget.ZIndex + 7
-                    TextLabel.LayoutOrder = thisWidget.ZIndex + 7
+                    TextLabel.LayoutOrder = 7
                     TextLabel.AutomaticSize = Enum.AutomaticSize.X
 
                     widgets.applyTextStyle(TextLabel)
@@ -546,7 +543,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                     Drag.Size = UDim2.fromScale(1, 0)
                     Drag.BackgroundTransparency = 1
                     Drag.BorderSizePixel = 0
-                    Drag.ZIndex = thisWidget.ZIndex
                     Drag.LayoutOrder = thisWidget.ZIndex
                     Drag.AutomaticSize = Enum.AutomaticSize.Y
                     widgets.UIListLayout(Drag, Enum.FillDirection.Horizontal, UDim.new(0, Iris._config.ItemInnerSpacing.X))
@@ -562,8 +558,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                         ColorBox.Name = "ColorBox"
                         ColorBox.BorderSizePixel = 0
                         ColorBox.Size = UDim2.fromOffset(textHeight, textHeight)
-                        ColorBox.ZIndex = thisWidget.ZIndex + 5
-                        ColorBox.LayoutOrder = thisWidget.ZIndex + 5
+                        ColorBox.LayoutOrder = 5
                         ColorBox.Image = widgets.ICONS.ALPHA_BACKGROUND_TEXTURE
                         ColorBox.ImageTransparency = 1
 
@@ -582,8 +577,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                     for index = 1, components do
                         local DragField: TextButton = Instance.new("TextButton")
                         DragField.Name = "DragField" .. tostring(index)
-                        DragField.ZIndex = thisWidget.ZIndex + index
-                        DragField.LayoutOrder = thisWidget.ZIndex + index
+                        DragField.LayoutOrder = index
                         if index == components then
                             DragField.Size = UDim2.new(lastComponentWidth, UDim.new())
                         else
@@ -615,8 +609,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
 
                         local InputField: TextBox = Instance.new("TextBox")
                         InputField.Name = "InputField"
-                        InputField.ZIndex = thisWidget.ZIndex + 5
-                        InputField.LayoutOrder = thisWidget.ZIndex + 2
                         InputField.Size = UDim2.new(1, 0, 1, 0)
                         InputField.BackgroundTransparency = 1
                         InputField.ClearTextOnFocus = false
@@ -689,8 +681,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                     TextLabel.Size = UDim2.fromOffset(0, textHeight)
                     TextLabel.BackgroundTransparency = 1
                     TextLabel.BorderSizePixel = 0
-                    TextLabel.ZIndex = thisWidget.ZIndex + 5
-                    TextLabel.LayoutOrder = thisWidget.ZIndex + 5
+                    TextLabel.LayoutOrder = 6
                     TextLabel.AutomaticSize = Enum.AutomaticSize.X
 
                     widgets.applyTextStyle(TextLabel)
@@ -946,7 +937,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                     Slider.Size = UDim2.fromScale(1, 0)
                     Slider.BackgroundTransparency = 1
                     Slider.BorderSizePixel = 0
-                    Slider.ZIndex = thisWidget.ZIndex
                     Slider.LayoutOrder = thisWidget.ZIndex
                     Slider.AutomaticSize = Enum.AutomaticSize.Y
                     widgets.UIListLayout(Slider, Enum.FillDirection.Horizontal, UDim.new(0, Iris._config.ItemInnerSpacing.X))
@@ -963,8 +953,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                     for index = 1, components do
                         local SliderField: TextButton = Instance.new("TextButton")
                         SliderField.Name = "SliderField" .. tostring(index)
-                        SliderField.ZIndex = thisWidget.ZIndex + index
-                        SliderField.LayoutOrder = thisWidget.ZIndex + index
+                        SliderField.LayoutOrder = index
                         if index == components then
                             SliderField.Size = UDim2.new(lastComponentWidth, UDim.new())
                         else
@@ -988,7 +977,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                         OverlayText.Size = UDim2.fromScale(1, 1)
                         OverlayText.BackgroundTransparency = 1
                         OverlayText.BorderSizePixel = 0
-                        OverlayText.ZIndex = thisWidget.ZIndex + 10
+                        OverlayText.ZIndex = 10
                         OverlayText.ClipsDescendants = true
 
                         widgets.applyTextStyle(OverlayText)
@@ -1008,8 +997,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
 
                         local InputField: TextBox = Instance.new("TextBox")
                         InputField.Name = "InputField"
-                        InputField.ZIndex = thisWidget.ZIndex + 5
-                        InputField.LayoutOrder = thisWidget.ZIndex + 2
                         InputField.Size = UDim2.new(1, 0, 1, 0)
                         InputField.BackgroundTransparency = 1
                         InputField.ClearTextOnFocus = false
@@ -1065,8 +1052,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
 
                         local GrabBar: Frame = Instance.new("Frame")
                         GrabBar.Name = "GrabBar"
-                        GrabBar.ZIndex = thisWidget.ZIndex + 5
-                        GrabBar.LayoutOrder = thisWidget.ZIndex + 5
+                        GrabBar.ZIndex = 5
                         GrabBar.AnchorPoint = Vector2.new(0.5, 0.5)
                         GrabBar.Position = UDim2.new(0, 0, 0.5, 0)
                         GrabBar.BorderSizePixel = 0
@@ -1086,8 +1072,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                     TextLabel.Size = UDim2.fromOffset(0, textHeight)
                     TextLabel.BackgroundTransparency = 1
                     TextLabel.BorderSizePixel = 0
-                    TextLabel.ZIndex = thisWidget.ZIndex + 5
-                    TextLabel.LayoutOrder = thisWidget.ZIndex + 5
+                    TextLabel.LayoutOrder = 5
                     TextLabel.AutomaticSize = Enum.AutomaticSize.X
 
                     widgets.applyTextStyle(TextLabel)

--- a/lib/widgets/Menu.lua
+++ b/lib/widgets/Menu.lua
@@ -109,7 +109,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             MenuBar.BackgroundColor3 = Iris._config.MenubarBgColor
             MenuBar.BackgroundTransparency = Iris._config.MenubarBgTransparency
             MenuBar.BorderSizePixel = 0
-            MenuBar.ZIndex = thisWidget.ZIndex
             MenuBar.LayoutOrder = thisWidget.ZIndex
             MenuBar.ClipsDescendants = true
 
@@ -177,7 +176,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 Menu.Size = UDim2.fromScale(1, 0)
                 Menu.Text = ""
                 Menu.AutomaticSize = Enum.AutomaticSize.Y
-                Menu.ZIndex = thisWidget.ZIndex
                 Menu.LayoutOrder = thisWidget.ZIndex
                 Menu.AutoButtonColor = false
 
@@ -190,8 +188,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 TextLabel.AnchorPoint = Vector2.new(0, 0)
                 TextLabel.BackgroundTransparency = 1
                 TextLabel.BorderSizePixel = 0
-                TextLabel.ZIndex = thisWidget.ZIndex + 2
-                TextLabel.LayoutOrder = thisWidget.ZIndex + 2
                 TextLabel.AutomaticSize = Enum.AutomaticSize.XY
 
                 widgets.applyTextStyle(TextLabel)
@@ -210,21 +206,19 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 Icon.ImageColor3 = Iris._config.TextColor
                 Icon.ImageTransparency = Iris._config.TextTransparency
                 Icon.Image = widgets.ICONS.RIGHT_POINTING_TRIANGLE
-                Icon.ZIndex = thisWidget.ZIndex + 3
-                Icon.LayoutOrder = thisWidget.ZIndex + 3
+                Icon.LayoutOrder = 1
 
                 Icon.Parent = Menu
             else
                 Menu = Instance.new("TextButton")
                 Menu.Name = "Menu"
-                Menu.Size = UDim2.fromScale(0, 0)
                 Menu.AutomaticSize = Enum.AutomaticSize.XY
+                Menu.Size = UDim2.fromScale(0, 0)
                 Menu.BackgroundColor3 = Iris._config.HeaderColor
                 Menu.BackgroundTransparency = 1
                 Menu.BorderSizePixel = 0
                 Menu.Text = ""
                 Menu.LayoutOrder = thisWidget.ZIndex
-                Menu.ZIndex = thisWidget.ZIndex
                 Menu.AutoButtonColor = false
                 Menu.ClipsDescendants = true
 
@@ -276,8 +270,8 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             ChildContainer.CanvasSize = UDim2.fromScale(0, 0)
             ChildContainer.VerticalScrollBarInset = Enum.ScrollBarInset.ScrollBar
 
-            ChildContainer.ZIndex = thisWidget.ZIndex + 6
-            ChildContainer.LayoutOrder = thisWidget.ZIndex + 6
+            ChildContainer.ZIndex = 6
+            ChildContainer.LayoutOrder = 6
             ChildContainer.ClipsDescendants = true
 
             -- Unfortunatley, ScrollingFrame does not work with UICorner
@@ -365,7 +359,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             MenuItem.Size = UDim2.fromScale(1, 0)
             MenuItem.Text = ""
             MenuItem.AutomaticSize = Enum.AutomaticSize.Y
-            MenuItem.ZIndex = thisWidget.ZIndex
             MenuItem.LayoutOrder = thisWidget.ZIndex
             MenuItem.AutoButtonColor = false
 
@@ -402,8 +395,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             TextLabel.AnchorPoint = Vector2.new(0, 0)
             TextLabel.BackgroundTransparency = 1
             TextLabel.BorderSizePixel = 0
-            TextLabel.ZIndex = thisWidget.ZIndex + 2
-            TextLabel.LayoutOrder = thisWidget.ZIndex + 2
             TextLabel.AutomaticSize = Enum.AutomaticSize.XY
 
             widgets.applyTextStyle(TextLabel)
@@ -415,8 +406,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             Shortcut.AnchorPoint = Vector2.new(0, 0)
             Shortcut.BackgroundTransparency = 1
             Shortcut.BorderSizePixel = 0
-            Shortcut.ZIndex = thisWidget.ZIndex + 3
-            Shortcut.LayoutOrder = thisWidget.ZIndex + 3
+            Shortcut.LayoutOrder = 1
             Shortcut.AutomaticSize = Enum.AutomaticSize.XY
 
             widgets.applyTextStyle(Shortcut)
@@ -482,7 +472,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             MenuItem.Size = UDim2.fromScale(1, 0)
             MenuItem.Text = ""
             MenuItem.AutomaticSize = Enum.AutomaticSize.Y
-            MenuItem.ZIndex = thisWidget.ZIndex
             MenuItem.LayoutOrder = thisWidget.ZIndex
             MenuItem.AutoButtonColor = false
 
@@ -521,8 +510,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             TextLabel.AnchorPoint = Vector2.new(0, 0)
             TextLabel.BackgroundTransparency = 1
             TextLabel.BorderSizePixel = 0
-            TextLabel.ZIndex = thisWidget.ZIndex + 2
-            TextLabel.LayoutOrder = thisWidget.ZIndex + 2
             TextLabel.AutomaticSize = Enum.AutomaticSize.XY
 
             widgets.applyTextStyle(TextLabel)
@@ -534,8 +521,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             Shortcut.AnchorPoint = Vector2.new(0, 0)
             Shortcut.BackgroundTransparency = 1
             Shortcut.BorderSizePixel = 0
-            Shortcut.ZIndex = thisWidget.ZIndex + 3
-            Shortcut.LayoutOrder = thisWidget.ZIndex + 3
+            Shortcut.LayoutOrder = 1
             Shortcut.AutomaticSize = Enum.AutomaticSize.XY
 
             widgets.applyTextStyle(Shortcut)
@@ -558,8 +544,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             Icon.ImageColor3 = Iris._config.TextColor
             Icon.ImageTransparency = Iris._config.TextTransparency
             Icon.Image = widgets.ICONS.CHECK_MARK
-            Icon.ZIndex = thisWidget.ZIndex + 4
-            Icon.LayoutOrder = thisWidget.ZIndex + 4
+            Icon.LayoutOrder = 2
 
             Icon.Parent = MenuItem
 

--- a/lib/widgets/Plot.lua
+++ b/lib/widgets/Plot.lua
@@ -27,7 +27,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 ProgressBar.Size = UDim2.new(Iris._config.ItemWidth, UDim.new())
                 ProgressBar.BackgroundTransparency = 1
                 ProgressBar.AutomaticSize = Enum.AutomaticSize.Y
-                ProgressBar.ZIndex = thisWidget.ZIndex
                 ProgressBar.LayoutOrder = thisWidget.ZIndex
 
                 widgets.UIListLayout(ProgressBar, Enum.FillDirection.Horizontal, UDim.new(0, Iris._config.ItemInnerSpacing.X))
@@ -40,8 +39,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 Bar.BorderSizePixel = 0
                 Bar.AutomaticSize = Enum.AutomaticSize.Y
                 Bar.ClipsDescendants = true
-                Bar.ZIndex = thisWidget.ZIndex + 1
-                Bar.LayoutOrder = thisWidget.ZIndex + 1
 
                 widgets.applyFrameStyle(Bar, true)
 
@@ -53,8 +50,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 Progress.BackgroundTransparency = Iris._config.PlotHistogramTransparency
                 Progress.BorderSizePixel = 0
                 Progress.AutomaticSize = Enum.AutomaticSize.Y
-                Progress.ZIndex = thisWidget.ZIndex + 2
-                Progress.LayoutOrder = thisWidget.ZIndex + 2
 
                 widgets.applyTextStyle(Progress)
                 widgets.UIPadding(Progress, Iris._config.FramePadding)
@@ -68,8 +63,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 Value.AutomaticSize = Enum.AutomaticSize.XY
                 Value.BackgroundTransparency = 1
                 Value.BorderSizePixel = 0
-                Value.ZIndex = thisWidget.ZIndex + 3
-                Value.LayoutOrder = thisWidget.ZIndex + 3
+                Value.ZIndex = 1
 
                 widgets.applyTextStyle(Value)
                 widgets.UIPadding(Value, Iris._config.FramePadding)
@@ -82,8 +76,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 TextLabel.AutomaticSize = Enum.AutomaticSize.XY
                 TextLabel.BackgroundTransparency = 1
                 TextLabel.BorderSizePixel = 0
-                TextLabel.ZIndex = thisWidget.ZIndex + 4
-                TextLabel.LayoutOrder = thisWidget.ZIndex + 4
+                TextLabel.LayoutOrder = 1
 
                 widgets.applyTextStyle(TextLabel)
                 widgets.UIPadding(Value, Iris._config.FramePadding)

--- a/lib/widgets/RadioButton.lua
+++ b/lib/widgets/RadioButton.lua
@@ -35,21 +35,18 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
         Generate = function(thisWidget: Types.Widget)
             local RadioButton: TextButton = Instance.new("TextButton")
             RadioButton.Name = "Iris_RadioButton"
+            RadioButton.AutomaticSize = Enum.AutomaticSize.XY
+            RadioButton.Size = UDim2.fromOffset(0, 0)
             RadioButton.BackgroundTransparency = 1
             RadioButton.BorderSizePixel = 0
-            RadioButton.Size = UDim2.fromOffset(0, 0)
             RadioButton.Text = ""
-            RadioButton.AutomaticSize = Enum.AutomaticSize.XY
-            RadioButton.ZIndex = thisWidget.ZIndex
-            RadioButton.AutoButtonColor = false
             RadioButton.LayoutOrder = thisWidget.ZIndex
+            RadioButton.AutoButtonColor = false
 
             local buttonSize: number = Iris._config.TextSize + 2 * (Iris._config.FramePadding.Y - 1)
             local Button: Frame = Instance.new("Frame")
             Button.Name = "Button"
             Button.Size = UDim2.fromOffset(buttonSize, buttonSize)
-            Button.ZIndex = thisWidget.ZIndex + 1
-            Button.LayoutOrder = thisWidget.ZIndex + 1
             Button.Parent = RadioButton
             Button.BackgroundColor3 = Iris._config.FrameBgColor
             Button.BackgroundTransparency = Iris._config.FrameBgTransparency
@@ -60,8 +57,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             Circle.Name = "Circle"
             Circle.Position = UDim2.fromOffset(Iris._config.FramePadding.Y, Iris._config.FramePadding.Y)
             Circle.Size = UDim2.fromOffset(Iris._config.TextSize - 2, Iris._config.TextSize - 2)
-            Circle.ZIndex = thisWidget.ZIndex + 1
-            Circle.LayoutOrder = thisWidget.ZIndex + 1
             Circle.Parent = Button
             Circle.BackgroundColor3 = Iris._config.CheckMarkColor
             Circle.BackgroundTransparency = Iris._config.CheckMarkTransparency
@@ -83,11 +78,9 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             local TextLabel: TextLabel = Instance.new("TextLabel")
             TextLabel.Name = "TextLabel"
             widgets.applyTextStyle(TextLabel)
-            TextLabel.Position = UDim2.new(0, buttonSize + Iris._config.ItemInnerSpacing.X, 0.5, 0)
-            TextLabel.ZIndex = thisWidget.ZIndex + 1
-            TextLabel.LayoutOrder = thisWidget.ZIndex + 1
             TextLabel.AutomaticSize = Enum.AutomaticSize.XY
             TextLabel.AnchorPoint = Vector2.new(0, 0.5)
+            TextLabel.Position = UDim2.new(0, buttonSize + Iris._config.ItemInnerSpacing.X, 0.5, 0)
             TextLabel.BackgroundTransparency = 1
             TextLabel.BorderSizePixel = 0
             TextLabel.Parent = RadioButton

--- a/lib/widgets/Root.lua
+++ b/lib/widgets/Root.lua
@@ -17,6 +17,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             if Iris._config.UseScreenGUIs then
                 PseudoWindowScreenGui = Instance.new("ScreenGui")
                 PseudoWindowScreenGui.ResetOnSpawn = false
+                PseudoWindowScreenGui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
                 PseudoWindowScreenGui.DisplayOrder = Iris._config.DisplayOrderOffset
                 PseudoWindowScreenGui.IgnoreGuiInset = Iris._config.IgnoreGuiInset
             else
@@ -34,6 +35,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             if Iris._config.UseScreenGUIs then
                 PopupScreenGui = Instance.new("ScreenGui")
                 PopupScreenGui.ResetOnSpawn = false
+                PopupScreenGui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
                 PopupScreenGui.DisplayOrder = Iris._config.DisplayOrderOffset + 1024 -- room for 1024 regular windows before overlap
                 PopupScreenGui.IgnoreGuiInset = Iris._config.IgnoreGuiInset
             else

--- a/lib/widgets/Text.lua
+++ b/lib/widgets/Text.lua
@@ -22,7 +22,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             Text.Size = UDim2.fromOffset(0, 0)
             Text.BackgroundTransparency = 1
             Text.BorderSizePixel = 0
-            Text.ZIndex = thisWidget.ZIndex
             Text.LayoutOrder = thisWidget.ZIndex
             Text.AutomaticSize = Enum.AutomaticSize.XY
 
@@ -78,7 +77,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             SeparatorText.BackgroundTransparency = 1
             SeparatorText.BorderSizePixel = 0
             SeparatorText.AutomaticSize = Enum.AutomaticSize.Y
-            SeparatorText.ZIndex = thisWidget.ZIndex
             SeparatorText.LayoutOrder = thisWidget.ZIndex
             SeparatorText.ClipsDescendants = true
 
@@ -92,8 +90,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             TextLabel.BackgroundTransparency = 1
             TextLabel.BorderSizePixel = 0
             TextLabel.AutomaticSize = Enum.AutomaticSize.XY
-            TextLabel.ZIndex = thisWidget.ZIndex + 1
-            TextLabel.LayoutOrder = thisWidget.ZIndex + 1
+            TextLabel.LayoutOrder = 1
 
             widgets.applyTextStyle(TextLabel)
 
@@ -106,8 +103,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             Left.BackgroundTransparency = Iris._config.SeparatorTransparency
             Left.BorderSizePixel = 0
             Left.Size = UDim2.fromOffset(Iris._config.SeparatorTextPadding.X - Iris._config.ItemSpacing.X, Iris._config.SeparatorTextBorderSize)
-            Left.ZIndex = thisWidget.ZIndex
-            Left.LayoutOrder = thisWidget.ZIndex
 
             Left.Parent = SeparatorText
 
@@ -118,8 +113,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             Right.BackgroundTransparency = Iris._config.SeparatorTransparency
             Right.BorderSizePixel = 0
             Right.Size = UDim2.new(1, 0, 0, Iris._config.SeparatorTextBorderSize)
-            Right.ZIndex = thisWidget.ZIndex + 2
-            Right.LayoutOrder = thisWidget.ZIndex + 2
+            Right.LayoutOrder = 2
 
             Right.Parent = SeparatorText
 

--- a/lib/widgets/Tree.lua
+++ b/lib/widgets/Tree.lua
@@ -73,7 +73,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 Tree.AutomaticSize = Enum.AutomaticSize.Y
                 Tree.BackgroundTransparency = 1
                 Tree.BorderSizePixel = 0
-                Tree.ZIndex = thisWidget.ZIndex
                 Tree.LayoutOrder = thisWidget.ZIndex
 
                 widgets.UIListLayout(Tree, Enum.FillDirection.Vertical, UDim.new(0, 0))
@@ -84,8 +83,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 ChildContainer.AutomaticSize = Enum.AutomaticSize.Y
                 ChildContainer.BackgroundTransparency = 1
                 ChildContainer.BorderSizePixel = 0
-                ChildContainer.ZIndex = thisWidget.ZIndex + 1
-                ChildContainer.LayoutOrder = thisWidget.ZIndex + 1
+                ChildContainer.LayoutOrder = 1
                 ChildContainer.Visible = false
                 -- ChildContainer.ClipsDescendants = true
 
@@ -101,8 +99,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 Header.AutomaticSize = Enum.AutomaticSize.Y
                 Header.BackgroundTransparency = 1
                 Header.BorderSizePixel = 0
-                Header.ZIndex = thisWidget.ZIndex
-                Header.LayoutOrder = thisWidget.ZIndex
                 Header.Parent = Tree
 
                 local Button: TextButton = Instance.new("TextButton")
@@ -110,8 +106,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 Button.BackgroundTransparency = 1
                 Button.BorderSizePixel = 0
                 Button.Text = ""
-                Button.ZIndex = thisWidget.ZIndex
-                Button.LayoutOrder = thisWidget.ZIndex
                 Button.AutoButtonColor = false
 
                 widgets.applyInteractionHighlights(thisWidget, Button, Header, {
@@ -138,8 +132,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 Arrow.ImageColor3 = Iris._config.TextColor
                 Arrow.ImageTransparency = Iris._config.TextTransparency
                 Arrow.ScaleType = Enum.ScaleType.Fit
-                Arrow.ZIndex = thisWidget.ZIndex
-                Arrow.LayoutOrder = thisWidget.ZIndex
 
                 Arrow.Parent = Button
 
@@ -149,8 +141,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 TextLabel.AutomaticSize = Enum.AutomaticSize.XY
                 TextLabel.BackgroundTransparency = 1
                 TextLabel.BorderSizePixel = 0
-                TextLabel.ZIndex = thisWidget.ZIndex
-                TextLabel.LayoutOrder = thisWidget.ZIndex
 
                 local TextPadding: UIPadding = widgets.UIPadding(TextLabel, Vector2.new(0, 0))
                 TextPadding.PaddingRight = UDim.new(0, 21)
@@ -204,7 +194,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 CollapsingHeader.AutomaticSize = Enum.AutomaticSize.Y
                 CollapsingHeader.BackgroundTransparency = 1
                 CollapsingHeader.BorderSizePixel = 0
-                CollapsingHeader.ZIndex = thisWidget.ZIndex
                 CollapsingHeader.LayoutOrder = thisWidget.ZIndex
 
                 widgets.UIListLayout(CollapsingHeader, Enum.FillDirection.Vertical, UDim.new(0, 0))
@@ -215,8 +204,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 ChildContainer.AutomaticSize = Enum.AutomaticSize.Y
                 ChildContainer.BackgroundTransparency = 1
                 ChildContainer.BorderSizePixel = 0
-                ChildContainer.ZIndex = thisWidget.ZIndex + 1
-                ChildContainer.LayoutOrder = thisWidget.ZIndex + 1
+                ChildContainer.LayoutOrder = 1
                 ChildContainer.Visible = false
                 -- ChildContainer.ClipsDescendants = true
 
@@ -232,8 +220,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 Header.AutomaticSize = Enum.AutomaticSize.Y
                 Header.BackgroundTransparency = 1
                 Header.BorderSizePixel = 0
-                Header.ZIndex = thisWidget.ZIndex
-                Header.LayoutOrder = thisWidget.ZIndex
                 Header.Parent = CollapsingHeader
 
                 local Button = Instance.new("TextButton")
@@ -244,8 +230,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 Button.BackgroundTransparency = Iris._config.HeaderTransparency
                 Button.BorderSizePixel = 0
                 Button.Text = ""
-                Button.ZIndex = thisWidget.ZIndex
-                Button.LayoutOrder = thisWidget.ZIndex
                 Button.AutoButtonColor = false
                 Button.ClipsDescendants = true
 
@@ -274,8 +258,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 Arrow.ImageColor3 = Iris._config.TextColor
                 Arrow.ImageTransparency = Iris._config.TextTransparency
                 Arrow.ScaleType = Enum.ScaleType.Fit
-                Arrow.ZIndex = thisWidget.ZIndex
-                Arrow.LayoutOrder = thisWidget.ZIndex
 
                 Arrow.Parent = Button
 
@@ -285,8 +267,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 TextLabel.AutomaticSize = Enum.AutomaticSize.XY
                 TextLabel.BackgroundTransparency = 1
                 TextLabel.BorderSizePixel = 0
-                TextLabel.ZIndex = thisWidget.ZIndex
-                TextLabel.LayoutOrder = thisWidget.ZIndex
 
                 local TextPadding: UIPadding = widgets.UIPadding(TextLabel, Vector2.new(0, 0))
                 TextPadding.PaddingRight = UDim.new(0, 21)

--- a/lib/widgets/Window.lua
+++ b/lib/widgets/Window.lua
@@ -47,8 +47,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             TooltipText.BackgroundTransparency = Iris._config.WindowBgTransparency
             TooltipText.BorderSizePixel = Iris._config.PopupBorderSize
             TooltipText.TextWrapped = Iris._config.TextWrapped
-            TooltipText.ZIndex = thisWidget.ZIndex + 1
-            TooltipText.LayoutOrder = thisWidget.ZIndex + 1
 
             widgets.applyTextStyle(TooltipText)
             widgets.UIStroke(TooltipText, Iris._config.WindowBorderSize, Iris._config.BorderActiveColor, Iris._config.BorderActiveTransparency)
@@ -388,6 +386,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             if thisWidget.usesScreenGUI then
                 Window = Instance.new("ScreenGui")
                 Window.ResetOnSpawn = false
+                Window.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
                 Window.DisplayOrder = Iris._config.DisplayOrderOffset
                 Window.IgnoreGuiInset = Iris._config.IgnoreGuiInset
             else
@@ -410,8 +409,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             WindowButton.AutoButtonColor = false
             WindowButton.Selectable = false
             WindowButton.SelectionImageObject = Iris.SelectionImageObject
-            WindowButton.ZIndex = thisWidget.ZIndex + 1
-            WindowButton.LayoutOrder = thisWidget.ZIndex + 1
 
             WindowButton.SelectionGroup = true
             WindowButton.SelectionBehaviorUp = Enum.SelectionBehavior.Stop
@@ -465,7 +462,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             ChildContainer.CanvasSize = UDim2.fromScale(0, 0)
             ChildContainer.VerticalScrollBarInset = Enum.ScrollBarInset.ScrollBar
 
-            ChildContainer.ZIndex = thisWidget.ZIndex + 3
             ChildContainer.LayoutOrder = thisWidget.ZIndex + 0xFFFF
             ChildContainer.ClipsDescendants = true
 
@@ -506,11 +502,9 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
 
             local TitleBar: Frame = Instance.new("Frame")
             TitleBar.Name = "TitleBar"
-            TitleBar.Size = UDim2.fromScale(1, 0)
             TitleBar.AutomaticSize = Enum.AutomaticSize.Y
+            TitleBar.Size = UDim2.fromScale(1, 0)
             TitleBar.BorderSizePixel = 0
-            TitleBar.ZIndex = thisWidget.ZIndex + 1
-            TitleBar.LayoutOrder = thisWidget.ZIndex + 1
             TitleBar.ClipsDescendants = true
 
             TitleBar.Parent = Content
@@ -538,7 +532,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             CollapseButton.BorderSizePixel = 0
             CollapseButton.AutoButtonColor = false
             CollapseButton.Text = ""
-            CollapseButton.ZIndex = thisWidget.ZIndex + 4
 
             widgets.UICorner(CollapseButton)
 
@@ -567,7 +560,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             CollapseArrow.Image = widgets.ICONS.MULTIPLICATION_SIGN
             CollapseArrow.ImageColor3 = Iris._config.TextColor
             CollapseArrow.ImageTransparency = Iris._config.TextTransparency
-            CollapseArrow.ZIndex = thisWidget.ZIndex + 5
             CollapseArrow.Parent = CollapseButton
 
             local CloseButton: TextButton = Instance.new("TextButton")
@@ -610,7 +602,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             CloseIcon.Image = widgets.ICONS.MULTIPLICATION_SIGN
             CloseIcon.ImageColor3 = Iris._config.TextColor
             CloseIcon.ImageTransparency = Iris._config.TextTransparency
-            CloseIcon.ZIndex = thisWidget.ZIndex + 5
             CloseIcon.Parent = CloseButton
 
             -- allowing fractional titlebar title location dosent seem useful, as opposed to Enum.LeftRight.
@@ -631,7 +622,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             Title.AutomaticSize = Enum.AutomaticSize.XY
             Title.BorderSizePixel = 0
             Title.BackgroundTransparency = 1
-            Title.ZIndex = thisWidget.ZIndex + 3
 
             widgets.applyTextStyle(Title)
             widgets.UIPadding(Title, Iris._config.FramePadding)
@@ -653,7 +643,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             ResizeGrip.ImageColor3 = Iris._config.ButtonColor
             ResizeGrip.ImageTransparency = Iris._config.ButtonTransparency
             ResizeGrip.Selectable = false
-            ResizeGrip.ZIndex = thisWidget.ZIndex + 3
+            ResizeGrip.ZIndex = 3
             ResizeGrip.Parent = WindowButton
 
             widgets.applyImageInteractionHighlights(thisWidget, ResizeGrip, ResizeGrip, {
@@ -684,8 +674,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             ResizeBorder.BorderSizePixel = 0
             ResizeBorder.Active = true
             ResizeBorder.Selectable = false
-            ResizeBorder.ZIndex = thisWidget.ZIndex
-            ResizeBorder.LayoutOrder = thisWidget.ZIndex
             ResizeBorder.ClipsDescendants = false
             ResizeBorder.Parent = WindowButton
 


### PR DESCRIPTION
# Simple Fix to Widget Layout Issues
Although this was addressed in #46, I was unsatisfied with regenerating widgets because they became out of order. Instead, I decided to redesign the layout system so that it is trivial to change the order of sibling elements without affecting children or parents. This involves a counter within each parent widget which assigns the LayoutOrder property and can check for new widgets added.

The current way to check for a new widget is by comparing the widget ZIndex property against the parent's counter. This ensures that if the widget order changes, all that needs to be done is change the Instance LayoutOrder property, no regeneration required.

## Additions
- Changed the display order to use sibling ZIndex instead of a global ZIndex ordering.
- Added new ZOffset and ZUpdate parent widget properties which decide the LayoutOrder of children.
- Widgets will use a LayoutOrder relative to siblings only. This allows for dynamic reorganising of widgets.
- Widgets will check that their ZIndex matches an expected value, otherwise causing a reshuffling of widgets.

## Tweaks and fixes
- Removed unnecessary ZIndex and LayoutOrder assignments for all widgets.