### PR TITLE
Remove argument from PopId

### DIFF
--- a/lib/Types.lua
+++ b/lib/Types.lua
@@ -334,7 +334,7 @@ export type Iris = {
 
     -- ID API
     PushId: (id: ID) -> (),
-    PopId: (id: ID) -> (),
+    PopId: () -> (),
     SetNextWidgetID: (id: ID) -> (),
 
     -- Config API


### PR DESCRIPTION
The function Iris.PopId has no actual parameters, and it does not have any parameters in the docs. As such, I think it should be removed from the type as well.